### PR TITLE
Bugfix Budget Bearbeitung

### DIFF
--- a/lib/components/bottom_nav_bar/bottom_nav_bar.dart
+++ b/lib/components/bottom_nav_bar/bottom_nav_bar.dart
@@ -60,8 +60,7 @@ class _BottomNavBarState extends State<BottomNavBar> {
                 width: 60,
                 height: 60,
                 decoration: BoxDecoration(
-                  shape: BoxShape.rectangle,
-                  borderRadius: const BorderRadius.all(Radius.circular(15)),
+                  shape: BoxShape.circle,
                   gradient: LinearGradient(
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,

--- a/lib/models/enums/transaction_types.dart
+++ b/lib/models/enums/transaction_types.dart
@@ -1,4 +1,5 @@
 import 'package:hive/hive.dart';
+
 import '/utils/consts/hive_consts.dart';
 
 @HiveType(typeId: transactionTypeId)

--- a/lib/screens/create_or_edit_budget_screen.dart
+++ b/lib/screens/create_or_edit_budget_screen.dart
@@ -18,7 +18,7 @@ import '/models/enums/transaction_types.dart';
 import '/models/screen_arguments/bottom_nav_bar_screen_arguments.dart';
 
 class CreateOrEditBudgetScreen extends StatefulWidget {
-  final int budgetBoxIndex;
+  final int budgetBoxIndex; // budgetBoxIndex == -1 = Budget bearbeiten / -2 = Standardbudget bearbeiten / >= 0 = Budget erstellen
   final String? budgetCategorie;
 
   const CreateOrEditBudgetScreen({
@@ -35,11 +35,11 @@ class _CreateOrEditBudgetScreenState extends State<CreateOrEditBudgetScreen> {
   final TextEditingController _categorieTextController = TextEditingController();
   final TextEditingController _budgetTextController = TextEditingController();
   final RoundedLoadingButtonController _saveButtonController = RoundedLoadingButtonController();
+  late DefaultBudget _loadedDefaultBudget;
+  late Budget _loadedBudget;
   String _categorieErrorText = '';
   String _budgetErrorText = '';
-  late Budget _loadedBudget;
-  late DefaultBudget _loadedDefaultBudget;
-  late bool _budgetExistsAlready;
+  bool _budgetExistsAlready = false;
 
   @override
   void initState() {
@@ -101,8 +101,8 @@ class _CreateOrEditBudgetScreenState extends State<CreateOrEditBudgetScreen> {
       Budget updatedBudget = Budget()
         ..categorie = _loadedBudget.categorie
         ..budget = formatMoneyAmountToDouble(_budgetTextController.text)
-        ..currentExpenditure = _loadedBudget.currentExpenditure
-        ..percentage = _loadedBudget.percentage
+        ..currentExpenditure = 0.0
+        ..percentage = 0.0
         ..budgetDate = _loadedBudget.budgetDate.toString();
       updatedBudget.updateBudget(updatedBudget, widget.budgetBoxIndex);
     }


### PR DESCRIPTION
- Budgets können wieder bearbeitet werden.
- _budgetExistsAlready muss gleich am Anfang initialisiert werden (keine late Initialisierung)
- currentExpenditure und percentage werden berechnet und können auf 0.0 gesetzt werden.
- Erstellungsbutton auf rund zurückgesetzt
- Kommentar zu budgetBoxIndex Parameter hinzugefügt