### PR TITLE
Bugfix Kontoliste aktualisieren

### DIFF
--- a/lib/screens/create_or_edit_account_screen.dart
+++ b/lib/screens/create_or_edit_account_screen.dart
@@ -163,17 +163,19 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
       ..toAccount = _accountName;
     // TODO newBooking.createBooking();
     // TODO entfernen? newBooking.createBooking(newBooking);
-    _updateAccount();
-    Navigator.pop(context);
-    Navigator.pop(context);
-    Navigator.pop(context);
+    _account.updateAccount(_account, widget.accountBoxIndex);
+    for (int i = 0; i < 4; i++) {
+      Navigator.pop(context);
+    }
+    Navigator.pushNamed(context, bottomNavBarRoute, arguments: BottomNavBarScreenArguments(2));
   }
 
   void _noPressed() {
-    _updateAccount();
-    Navigator.pop(context);
-    Navigator.pop(context);
-    Navigator.pop(context);
+    _account.updateAccount(_account, widget.accountBoxIndex);
+    for (int i = 0; i < 4; i++) {
+      Navigator.pop(context);
+    }
+    Navigator.pushNamed(context, bottomNavBarRoute, arguments: BottomNavBarScreenArguments(2));
   }
 
   void _updateAccount() {


### PR DESCRIPTION
- Kontoliste wird nach dem bearbeiten eines Kontos richtig aktualisiert => Kontoliste Seite muss nochmals auf den Navigator Stack gepusht werden. Davor wurde nur auf die alte Kontoliste zurück navigiert die, die alten Kontodaten hatte und angezeigt hat.