### PR TITLE
Implement preselected account

### DIFF
--- a/lib/components/cards/booking_card.dart
+++ b/lib/components/cards/booking_card.dart
@@ -110,27 +110,30 @@ class BookingCard extends StatelessWidget {
                       decoration: BoxDecoration(
                         border: Border(right: BorderSide(color: Colors.grey.shade700, width: 0.5)),
                       ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name
-                              ? const SizedBox()
-                              : Text(booking.categorie, overflow: TextOverflow.ellipsis),
-                          Padding(
-                            padding: EdgeInsets.only(
-                                top: booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name ? 0.0 : 8.0),
-                            child: Text(booking.fromAccount, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Colors.grey)),
-                          ),
-                          booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name
-                              ? Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    const Icon(Icons.keyboard_arrow_down_rounded, color: Colors.grey, size: 16.0),
-                                    Text(booking.toAccount, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Colors.grey)),
-                                  ],
-                                )
-                              : const SizedBox(),
-                        ],
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name
+                                ? const SizedBox()
+                                : Text(booking.categorie, overflow: TextOverflow.ellipsis),
+                            Padding(
+                              padding: EdgeInsets.only(
+                                  top: booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name ? 0.0 : 8.0),
+                              child: Text(booking.fromAccount, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Colors.grey)),
+                            ),
+                            booking.transactionType == TransactionType.transfer.name || booking.transactionType == TransactionType.investment.name
+                                ? Column(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      const Icon(Icons.keyboard_arrow_down_rounded, color: Colors.grey, size: 16.0),
+                                      Text(booking.toAccount, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Colors.grey)),
+                                    ],
+                                  )
+                                : const SizedBox(),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -140,7 +143,7 @@ class BookingCard extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
                         Padding(
-                          padding: const EdgeInsets.only(left: 12.0),
+                          padding: const EdgeInsets.only(left: 8.0),
                           child: Text(booking.title),
                         ),
                       ],

--- a/lib/components/input_fields/account_input_field.dart
+++ b/lib/components/input_fields/account_input_field.dart
@@ -9,12 +9,16 @@ class AccountInputField extends StatefulWidget {
   final TextEditingController textController;
   final String errorText;
   final String hintText;
+  final bool checkPreselectedAccount;
+  final String preselectedAccountType;
 
   const AccountInputField({
     Key? key,
     required this.textController,
     required this.errorText,
     this.hintText = 'Konto',
+    this.checkPreselectedAccount = false,
+    this.preselectedAccountType = '',
   }) : super(key: key);
 
   @override
@@ -23,6 +27,14 @@ class AccountInputField extends StatefulWidget {
 
 class _AccountInputFieldState extends State<AccountInputField> {
   List<String> accountNames = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.checkPreselectedAccount) {
+      _getPreselectedAccountName();
+    }
+  }
 
   void _openBottomSheetWithAccountList(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -89,6 +101,10 @@ class _AccountInputFieldState extends State<AccountInputField> {
   Future<List<String>> _loadAccountNameList() async {
     accountNames = await Account.loadAccountNames();
     return accountNames;
+  }
+
+  void _getPreselectedAccountName() async {
+    widget.textController.text = await Account.loadPreselectedAccountNameFor(widget.preselectedAccountType);
   }
 
   @override

--- a/lib/components/input_fields/account_input_field.dart
+++ b/lib/components/input_fields/account_input_field.dart
@@ -9,16 +9,12 @@ class AccountInputField extends StatefulWidget {
   final TextEditingController textController;
   final String errorText;
   final String hintText;
-  final bool checkPreselectedAccount;
-  final String preselectedAccountType;
 
   const AccountInputField({
     Key? key,
     required this.textController,
     required this.errorText,
     this.hintText = 'Konto',
-    this.checkPreselectedAccount = false,
-    this.preselectedAccountType = '',
   }) : super(key: key);
 
   @override
@@ -27,14 +23,6 @@ class AccountInputField extends StatefulWidget {
 
 class _AccountInputFieldState extends State<AccountInputField> {
   List<String> accountNames = [];
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.checkPreselectedAccount) {
-      _getPreselectedAccountName();
-    }
-  }
 
   void _openBottomSheetWithAccountList(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -101,10 +89,6 @@ class _AccountInputFieldState extends State<AccountInputField> {
   Future<List<String>> _loadAccountNameList() async {
     accountNames = await Account.loadAccountNames();
     return accountNames;
-  }
-
-  void _getPreselectedAccountName() async {
-    widget.textController.text = await Account.loadPreselectedAccountNameFor(widget.preselectedAccountType);
   }
 
   @override

--- a/lib/components/input_fields/account_type_input_field.dart
+++ b/lib/components/input_fields/account_type_input_field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../dialogs/list_dialog.dart';
+
 import '/models/enums/account_types.dart';
 
 class AccountTypeInputField extends StatelessWidget {

--- a/lib/components/input_fields/preselect_account_input_field.dart
+++ b/lib/components/input_fields/preselect_account_input_field.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
-import '/models/account.dart';
+import '/models/primary_account.dart';
 import '/models/enums/preselect_account_types.dart';
 
 import '../deco/bottom_sheet_line.dart';
@@ -20,7 +20,7 @@ class PreselectAccountInputField extends StatefulWidget {
 
 class _PreselectAccountInputFieldState extends State<PreselectAccountInputField> {
   List<bool> preselectedAccount = [false, false, false, false, false, false];
-  Map<String, String> _currentPreselectedAccountNames = {};
+  Map<String, String> _currentPrimaryAccounts = {};
 
   void _openBottomSheetWithTransactionTypes(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -51,9 +51,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                               children: [
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.income.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.income.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.income.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.income.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.income.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[0],
                                   onChanged: (bool? value) {
@@ -67,9 +67,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.outcome.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.outcome.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.outcome.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.outcome.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.outcome.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[1],
                                   onChanged: (bool? value) {
@@ -83,9 +83,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.transferFrom.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.transferFrom.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.transferFrom.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.transferFrom.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.transferFrom.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[2],
                                   onChanged: (bool? value) {
@@ -99,9 +99,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.transferTo.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.transferTo.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.transferTo.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.transferTo.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.transferTo.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[3],
                                   onChanged: (bool? value) {
@@ -115,9 +115,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.investmentFrom.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.investmentFrom.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.investmentFrom.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.investmentFrom.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.investmentFrom.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[4],
                                   onChanged: (bool? value) {
@@ -131,9 +131,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 CheckboxListTile(
                                   title: Text(PreselectAccountType.investmentTo.name),
-                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.investmentTo.name] == null
+                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.investmentTo.name] == null
                                       ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.investmentTo.name].toString()),
+                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.investmentTo.name].toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[5],
                                   onChanged: (bool? value) {
@@ -182,8 +182,7 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
 
   Future<List<bool>> _loadPreselectedAccountList() async {
     _setPrimaryAccounts();
-    _currentPreselectedAccountNames = await Account.loadCurrentPreselectedAccountNames();
-    print(_currentPreselectedAccountNames);
+    _currentPrimaryAccounts = await PrimaryAccount.getCurrentPrimaryAccounts();
     return preselectedAccount;
   }
 

--- a/lib/components/input_fields/preselect_account_input_field.dart
+++ b/lib/components/input_fields/preselect_account_input_field.dart
@@ -20,7 +20,7 @@ class PreselectAccountInputField extends StatefulWidget {
 
 class _PreselectAccountInputFieldState extends State<PreselectAccountInputField> {
   List<bool> preselectedAccount = [false, false, false, false, false, false];
-  Map<String, String> _currentPrimaryAccounts = {};
+  List<PrimaryAccount> _currentPrimaryAccounts = [];
 
   void _openBottomSheetWithTransactionTypes(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -50,10 +50,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                             Column(
                               children: [
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.income.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.income.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.income.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[0].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[0].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[0].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[0],
                                   onChanged: (bool? value) {
@@ -66,10 +65,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                   checkColor: Colors.cyanAccent,
                                 ),
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.outcome.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.outcome.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.outcome.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[1].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[1].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[1].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[1],
                                   onChanged: (bool? value) {
@@ -82,10 +80,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                   checkColor: Colors.cyanAccent,
                                 ),
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.transferFrom.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.transferFrom.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.transferFrom.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[2].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[2].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[2].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[2],
                                   onChanged: (bool? value) {
@@ -98,10 +95,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                   checkColor: Colors.cyanAccent,
                                 ),
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.transferTo.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.transferTo.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.transferTo.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[3].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[3].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[3].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[3],
                                   onChanged: (bool? value) {
@@ -114,10 +110,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                   checkColor: Colors.cyanAccent,
                                 ),
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.investmentFrom.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.investmentFrom.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.investmentFrom.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[4].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[4].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[4].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[4],
                                   onChanged: (bool? value) {
@@ -130,10 +125,9 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                   checkColor: Colors.cyanAccent,
                                 ),
                                 CheckboxListTile(
-                                  title: Text(PreselectAccountType.investmentTo.name),
-                                  subtitle: _currentPrimaryAccounts[PreselectAccountType.investmentTo.name] == null
-                                      ? null
-                                      : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[PreselectAccountType.investmentTo.name].toString()),
+                                  title: Text(_currentPrimaryAccounts[5].transactionType),
+                                  subtitle:
+                                      _currentPrimaryAccounts[5].accountName == '' ? null : Text('Aktuelles Primärkonto: ' + _currentPrimaryAccounts[5].accountName.toString()),
                                   controlAffinity: ListTileControlAffinity.leading,
                                   value: preselectedAccount[5],
                                   onChanged: (bool? value) {
@@ -182,7 +176,7 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
 
   Future<List<bool>> _loadPreselectedAccountList() async {
     _setPrimaryAccounts();
-    _currentPrimaryAccounts = await PrimaryAccount.getCurrentPrimaryAccounts();
+    _currentPrimaryAccounts = await PrimaryAccount.loadPrimaryAccountList();
     return preselectedAccount;
   }
 

--- a/lib/components/input_fields/preselect_account_input_field.dart
+++ b/lib/components/input_fields/preselect_account_input_field.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+
+import '../../models/account.dart';
+import '/models/enums/preselect_account_types.dart';
+
+import '../deco/bottom_sheet_line.dart';
+
+class PreselectAccountInputField extends StatefulWidget {
+  final TextEditingController textController;
+
+  const PreselectAccountInputField({
+    Key? key,
+    required this.textController,
+  }) : super(key: key);
+
+  @override
+  State<PreselectAccountInputField> createState() => _PreselectAccountInputFieldState();
+}
+
+class _PreselectAccountInputFieldState extends State<PreselectAccountInputField> {
+  List<bool> preselectedAccount = [];
+
+  void _openBottomSheetWithTransactionTypes(BuildContext context) {
+    showCupertinoModalBottomSheet<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return Material(
+          child: SizedBox(
+            height: 400,
+            child: ListView(
+              children: [
+                FutureBuilder(
+                  future: _loadPreselectedAccountList(),
+                  builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+                    switch (snapshot.connectionState) {
+                      case ConnectionState.waiting:
+                        return const SizedBox();
+                      case ConnectionState.done:
+                        return Center(
+                          child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                            return ListView(
+                              shrinkWrap: true,
+                              children: [
+                                const BottomSheetLine(),
+                                const Padding(
+                                  padding: EdgeInsets.only(top: 12.0, left: 20.0, bottom: 8.0),
+                                  child: Text('Vorselektiertes Konto für:', style: TextStyle(fontSize: 18.0)),
+                                ),
+                                Column(
+                                  children: [
+                                    // TODO hier weitermachen
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.income.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[0],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[0] = value!;
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            );
+                          }),
+                        );
+                      default:
+                        return const SizedBox();
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<List<bool>> _loadPreselectedAccountList() async {
+    if (widget.textController.text.isEmpty) {
+      preselectedAccount = [false, false, false, false, false, false];
+    } else {
+      preselectedAccount = await Account.loadPreselectedAccountList();
+    }
+    return preselectedAccount;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: widget.textController,
+      textAlignVertical: TextAlignVertical.center,
+      showCursor: false,
+      readOnly: true,
+      onTap: () => _openBottomSheetWithTransactionTypes(context),
+      decoration: const InputDecoration(
+        hintText: 'Vorselektiertes Konto für',
+        prefixIcon: Icon(
+          Icons.star_border_rounded,
+          color: Colors.grey,
+        ),
+        focusedBorder: UnderlineInputBorder(
+          borderSide: BorderSide(color: Colors.cyanAccent, width: 1.5),
+        ),
+        // TODO errorText: widget.errorText.isEmpty ? null : widget.errorText,
+      ),
+    );
+  }
+}

--- a/lib/components/input_fields/preselect_account_input_field.dart
+++ b/lib/components/input_fields/preselect_account_input_field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
+import '/models/account.dart';
 import '/models/enums/preselect_account_types.dart';
 
 import '../deco/bottom_sheet_line.dart';
@@ -19,6 +20,7 @@ class PreselectAccountInputField extends StatefulWidget {
 
 class _PreselectAccountInputFieldState extends State<PreselectAccountInputField> {
   List<bool> preselectedAccount = [false, false, false, false, false, false];
+  Map<String, String> _currentPreselectedAccountNames = {};
 
   void _openBottomSheetWithTransactionTypes(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -26,118 +28,133 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
       builder: (BuildContext context) {
         return Material(
           child: SizedBox(
-            height: 400,
-            child: ListView(
-              children: [
-                FutureBuilder(
-                  future: _loadPreselectedAccountList(),
-                  builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-                    switch (snapshot.connectionState) {
-                      case ConnectionState.waiting:
-                        return const SizedBox();
-                      case ConnectionState.done:
-                        return Center(
-                          child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-                            return ListView(
-                              shrinkWrap: true,
+            height: 520.0,
+            child: FutureBuilder(
+              future: _loadPreselectedAccountList(),
+              builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+                switch (snapshot.connectionState) {
+                  case ConnectionState.waiting:
+                    return const SizedBox();
+                  case ConnectionState.done:
+                    return Center(
+                      child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const BottomSheetLine(),
+                            const Padding(
+                              padding: EdgeInsets.only(top: 12.0, left: 28.0, bottom: 8.0),
+                              child: Text('Vorselektiertes Konto für:', style: TextStyle(fontSize: 18.0)),
+                            ),
+                            const Divider(),
+                            Column(
                               children: [
-                                const BottomSheetLine(),
-                                const Padding(
-                                  padding: EdgeInsets.only(top: 12.0, left: 20.0, bottom: 8.0),
-                                  child: Text('Vorselektiertes Konto für:', style: TextStyle(fontSize: 18.0)),
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.income.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.income.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.income.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[0],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[0] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[0], PreselectAccountType.income.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
                                 ),
-                                Column(
-                                  children: [
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.income.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[0],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[0] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[0], PreselectAccountType.income.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.outcome.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[1],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[1] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[1], PreselectAccountType.outcome.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.transferFrom.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[2],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[2] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[2], PreselectAccountType.transferFrom.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.transferTo.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[3],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[3] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[3], PreselectAccountType.transferTo.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.investmentFrom.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[4],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[4] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[4], PreselectAccountType.investmentFrom.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                    CheckboxListTile(
-                                      title: Text(PreselectAccountType.investmentTo.name),
-                                      controlAffinity: ListTileControlAffinity.leading,
-                                      value: preselectedAccount[5],
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          preselectedAccount[5] = value!;
-                                          _setPreselectedAccountText(preselectedAccount[5], PreselectAccountType.investmentTo.name);
-                                        });
-                                      },
-                                      activeColor: Colors.grey,
-                                      checkColor: Colors.cyanAccent,
-                                    ),
-                                  ],
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.outcome.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.outcome.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.outcome.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[1],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[1] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[1], PreselectAccountType.outcome.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
+                                ),
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.transferFrom.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.transferFrom.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.transferFrom.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[2],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[2] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[2], PreselectAccountType.transferFrom.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
+                                ),
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.transferTo.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.transferTo.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.transferTo.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[3],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[3] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[3], PreselectAccountType.transferTo.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
+                                ),
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.investmentFrom.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.investmentFrom.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.investmentFrom.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[4],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[4] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[4], PreselectAccountType.investmentFrom.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
+                                ),
+                                CheckboxListTile(
+                                  title: Text(PreselectAccountType.investmentTo.name),
+                                  subtitle: _currentPreselectedAccountNames[PreselectAccountType.investmentTo.name] == null
+                                      ? null
+                                      : Text('Aktuelles Primärkonto: ' + _currentPreselectedAccountNames[PreselectAccountType.investmentTo.name].toString()),
+                                  controlAffinity: ListTileControlAffinity.leading,
+                                  value: preselectedAccount[5],
+                                  onChanged: (bool? value) {
+                                    setState(() {
+                                      preselectedAccount[5] = value!;
+                                      _setPreselectedAccountText(preselectedAccount[5], PreselectAccountType.investmentTo.name);
+                                    });
+                                  },
+                                  activeColor: Colors.grey,
+                                  checkColor: Colors.cyanAccent,
                                 ),
                               ],
-                            );
-                          }),
+                            ),
+                          ],
                         );
-                      default:
-                        return const SizedBox();
-                    }
-                  },
-                ),
-              ],
+                      }),
+                    );
+                  default:
+                    return const SizedBox();
+                }
+              },
             ),
           ),
         );
@@ -165,6 +182,8 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
 
   Future<List<bool>> _loadPreselectedAccountList() async {
     _setPrimaryAccounts();
+    _currentPreselectedAccountNames = await Account.loadCurrentPreselectedAccountNames();
+    print(_currentPreselectedAccountNames);
     return preselectedAccount;
   }
 

--- a/lib/components/input_fields/preselect_account_input_field.dart
+++ b/lib/components/input_fields/preselect_account_input_field.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
-import '../../models/account.dart';
 import '/models/enums/preselect_account_types.dart';
 
 import '../deco/bottom_sheet_line.dart';
@@ -19,7 +18,7 @@ class PreselectAccountInputField extends StatefulWidget {
 }
 
 class _PreselectAccountInputFieldState extends State<PreselectAccountInputField> {
-  List<bool> preselectedAccount = [];
+  List<bool> preselectedAccount = [false, false, false, false, false, false];
 
   void _openBottomSheetWithTransactionTypes(BuildContext context) {
     showCupertinoModalBottomSheet<void>(
@@ -49,7 +48,6 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                 ),
                                 Column(
                                   children: [
-                                    // TODO hier weitermachen
                                     CheckboxListTile(
                                       title: Text(PreselectAccountType.income.name),
                                       controlAffinity: ListTileControlAffinity.leading,
@@ -57,6 +55,72 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
                                       onChanged: (bool? value) {
                                         setState(() {
                                           preselectedAccount[0] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[0], PreselectAccountType.income.name);
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.outcome.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[1],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[1] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[1], PreselectAccountType.outcome.name);
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.transferFrom.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[2],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[2] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[2], PreselectAccountType.transferFrom.name);
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.transferTo.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[3],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[3] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[3], PreselectAccountType.transferTo.name);
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.investmentFrom.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[4],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[4] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[4], PreselectAccountType.investmentFrom.name);
+                                        });
+                                      },
+                                      activeColor: Colors.grey,
+                                      checkColor: Colors.cyanAccent,
+                                    ),
+                                    CheckboxListTile(
+                                      title: Text(PreselectAccountType.investmentTo.name),
+                                      controlAffinity: ListTileControlAffinity.leading,
+                                      value: preselectedAccount[5],
+                                      onChanged: (bool? value) {
+                                        setState(() {
+                                          preselectedAccount[5] = value!;
+                                          _setPreselectedAccountText(preselectedAccount[5], PreselectAccountType.investmentTo.name);
                                         });
                                       },
                                       activeColor: Colors.grey,
@@ -81,13 +145,36 @@ class _PreselectAccountInputFieldState extends State<PreselectAccountInputField>
     );
   }
 
-  Future<List<bool>> _loadPreselectedAccountList() async {
-    if (widget.textController.text.isEmpty) {
-      preselectedAccount = [false, false, false, false, false, false];
+  void _setPreselectedAccountText(bool isNewAccountSelected, String newText) {
+    String separator = ', ';
+    if (isNewAccountSelected) {
+      widget.textController.text += widget.textController.text.isEmpty ? newText : separator + newText;
     } else {
-      preselectedAccount = await Account.loadPreselectedAccountList();
+      widget.textController.text = widget.textController.text.replaceFirst(newText, '');
+      if (widget.textController.text.startsWith(separator)) {
+        widget.textController.text = widget.textController.text.replaceFirst(separator, '');
+      }
+      if (widget.textController.text.endsWith(separator)) {
+        widget.textController.text = widget.textController.text.substring(0, widget.textController.text.length - 2);
+      }
+      if (widget.textController.text.contains(separator + ',')) {
+        widget.textController.text = widget.textController.text.replaceFirst(separator + ',', ',');
+      }
     }
+  }
+
+  Future<List<bool>> _loadPreselectedAccountList() async {
+    _setPrimaryAccounts();
     return preselectedAccount;
+  }
+
+  void _setPrimaryAccounts() {
+    widget.textController.text.contains(PreselectAccountType.income.name) ? preselectedAccount[0] = true : preselectedAccount[0] = false;
+    widget.textController.text.contains(PreselectAccountType.outcome.name) ? preselectedAccount[1] = true : preselectedAccount[1] = false;
+    widget.textController.text.contains(PreselectAccountType.transferFrom.name) ? preselectedAccount[2] = true : preselectedAccount[2] = false;
+    widget.textController.text.contains(PreselectAccountType.transferTo.name) ? preselectedAccount[3] = true : preselectedAccount[3] = false;
+    widget.textController.text.contains(PreselectAccountType.investmentFrom.name) ? preselectedAccount[4] = true : preselectedAccount[4] = false;
+    widget.textController.text.contains(PreselectAccountType.investmentTo.name) ? preselectedAccount[5] = true : preselectedAccount[5] = false;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:haushaltsbuch/models/intro_screen_state.dart';
-import 'package:haushaltsbuch/screens/splash_screen.dart';
 import 'package:hive_flutter/adapters.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -14,6 +12,8 @@ import 'models/budget.dart';
 import 'models/default_budget.dart';
 import 'models/enums/transaction_types.dart';
 import 'models/global_state.dart';
+import 'models/intro_screen_state.dart';
+import 'models/primary_account.dart';
 import 'models/screen_arguments/edit_budget_screen_arguments.dart';
 import 'models/screen_arguments/bottom_nav_bar_screen_arguments.dart';
 import 'models/screen_arguments/account_details_screen_arguments.dart';
@@ -26,7 +26,6 @@ import 'models/screen_arguments/create_or_edit_categorie_screen_arguments.dart';
 import '/components/bottom_nav_bar/bottom_nav_bar.dart';
 
 import '/screens/overview_budgets_screen.dart';
-import '/screens/introduction_screens.dart';
 import '/screens/create_or_edit_booking_screen.dart';
 import '/screens/create_or_edit_account_screen.dart';
 import '/screens/create_or_edit_categorie_screen.dart';
@@ -36,6 +35,7 @@ import '/screens/create_or_edit_budget_screen.dart';
 import '/screens/categorie_amount_list_screen.dart';
 import '/screens/edit_budget_screen.dart';
 import '/screens/settings_screen.dart';
+import '/screens/splash_screen.dart';
 
 void main() async {
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
@@ -44,6 +44,7 @@ void main() async {
   await Hive.initFlutter();
   Hive.registerAdapter(BookingAdapter());
   Hive.registerAdapter(AccountAdapter());
+  Hive.registerAdapter(PrimaryAccountAdapter());
   Hive.registerAdapter(CategorieAdapter());
   Hive.registerAdapter(BudgetAdapter());
   Hive.registerAdapter(DefaultBudgetAdapter());

--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -1,3 +1,4 @@
+import 'package:haushaltsbuch/models/enums/preselect_account_types.dart';
 import 'package:hive/hive.dart';
 
 import '/models/enums/transaction_types.dart';
@@ -250,10 +251,60 @@ class Account extends HiveObject {
     return accountTypeBalanceMap;
   }
 
-  static Future<List<bool>> loadPreselectedAccountList() async {
+  static Future<String> loadPreselectedAccountNameFor(String preselectedAccountType) async {
     var accountBox = await Hive.openBox(accountsBox);
-    // TODO
-    return [];
+    for (int i = 0; i < accountBox.length; i++) {
+      Account account = await accountBox.getAt(i);
+      if (preselectedAccountType == PreselectAccountType.income.name && account.primaryIncomeAccount) {
+        return account.name;
+      }
+      if (preselectedAccountType == PreselectAccountType.outcome.name && account.primaryOutcomeAccount) {
+        return account.name;
+      }
+      if (preselectedAccountType == PreselectAccountType.transferFrom.name && account.primaryTransferFromAccount) {
+        return account.name;
+      }
+      if (preselectedAccountType == PreselectAccountType.transferTo.name && account.primaryTransferToAccount) {
+        return account.name;
+      }
+      if (preselectedAccountType == PreselectAccountType.investmentFrom.name && account.primaryInvestmentFromAccount) {
+        return account.name;
+      }
+      if (preselectedAccountType == PreselectAccountType.investmentTo.name && account.primaryInvestmentToAccount) {
+        return account.name;
+      }
+    }
+    return '';
+  }
+
+  static Future<Map<String, String>> loadCurrentPreselectedAccountNames() async {
+    var accountBox = await Hive.openBox(accountsBox);
+    Map<String, String> primaryAccountNames = {};
+    for (int i = 0; i < accountBox.length; i++) {
+      Account account = await accountBox.getAt(i);
+      if (account.primaryIncomeAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.income.name: account.name});
+      }
+      if (account.primaryOutcomeAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.outcome.name: account.name});
+      }
+      if (account.primaryTransferFromAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.transferFrom.name: account.name});
+      }
+      if (account.primaryTransferToAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.transferTo.name: account.name});
+      }
+      if (account.primaryInvestmentFromAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.investmentFrom.name: account.name});
+      }
+      if (account.primaryInvestmentToAccount) {
+        primaryAccountNames.addAll({PreselectAccountType.investmentTo.name: account.name});
+      }
+      if (primaryAccountNames.length == 6) {
+        break;
+      }
+    }
+    return primaryAccountNames;
   }
 
   static void createStartAccounts() async {

--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -17,6 +17,18 @@ class Account extends HiveObject {
   late String accountType;
   @HiveField(2)
   late String bankBalance;
+  @HiveField(3)
+  late bool primaryIncomeAccount;
+  @HiveField(4)
+  late bool primaryOutcomeAccount;
+  @HiveField(5)
+  late bool primaryTransferFromAccount;
+  @HiveField(6)
+  late bool primaryTransferToAccount;
+  @HiveField(7)
+  late bool primaryInvestmentFromAccount;
+  @HiveField(8)
+  late bool primaryInvestmentToAccount;
 
   void createAccount(Account newAccount) async {
     var accountBox = await Hive.openBox(accountsBox);
@@ -238,6 +250,12 @@ class Account extends HiveObject {
     return accountTypeBalanceMap;
   }
 
+  static Future<List<bool>> loadPreselectedAccountList() async {
+    var accountBox = await Hive.openBox(accountsBox);
+    // TODO
+    return [];
+  }
+
   static void createStartAccounts() async {
     var accountBox = await Hive.openBox(accountsBox);
     if (accountBox.isNotEmpty) {
@@ -246,22 +264,46 @@ class Account extends HiveObject {
     Account cashAccount = Account()
       ..name = 'Geldbeutel'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.cash.name;
+      ..accountType = AccountType.cash.name
+      ..primaryIncomeAccount = false
+      ..primaryOutcomeAccount = false
+      ..primaryTransferFromAccount = false
+      ..primaryTransferToAccount = false
+      ..primaryInvestmentFromAccount = false
+      ..primaryInvestmentToAccount = false;
     cashAccount.createAccount(cashAccount);
     Account giroAccount = Account()
       ..name = 'Girokonto'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.account.name;
+      ..accountType = AccountType.account.name
+      ..primaryIncomeAccount = false
+      ..primaryOutcomeAccount = false
+      ..primaryTransferFromAccount = false
+      ..primaryTransferToAccount = false
+      ..primaryInvestmentFromAccount = false
+      ..primaryInvestmentToAccount = false;
     giroAccount.createAccount(giroAccount);
     Account billingAccount = Account()
       ..name = 'Verechnungskonto'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.account.name;
+      ..accountType = AccountType.account.name
+      ..primaryIncomeAccount = false
+      ..primaryOutcomeAccount = false
+      ..primaryTransferFromAccount = false
+      ..primaryTransferToAccount = false
+      ..primaryInvestmentFromAccount = false
+      ..primaryInvestmentToAccount = false;
     billingAccount.createAccount(billingAccount);
     Account capitalInvestmentAccount = Account()
       ..name = 'Aktiendepot'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.capitalInvestments.name;
+      ..accountType = AccountType.capitalInvestments.name
+      ..primaryIncomeAccount = false
+      ..primaryOutcomeAccount = false
+      ..primaryTransferFromAccount = false
+      ..primaryTransferToAccount = false
+      ..primaryInvestmentFromAccount = false
+      ..primaryInvestmentToAccount = false;
     capitalInvestmentAccount.createAccount(capitalInvestmentAccount);
   }
 }
@@ -275,7 +317,13 @@ class AccountAdapter extends TypeAdapter<Account> {
     return Account()
       ..name = reader.read()
       ..accountType = reader.read()
-      ..bankBalance = reader.read();
+      ..bankBalance = reader.read()
+      ..primaryIncomeAccount = reader.read()
+      ..primaryOutcomeAccount = reader.read()
+      ..primaryTransferFromAccount = reader.read()
+      ..primaryTransferToAccount = reader.read()
+      ..primaryInvestmentFromAccount = reader.read()
+      ..primaryInvestmentToAccount = reader.read();
   }
 
   @override
@@ -283,5 +331,11 @@ class AccountAdapter extends TypeAdapter<Account> {
     writer.write(obj.name);
     writer.write(obj.accountType);
     writer.write(obj.bankBalance);
+    writer.write(obj.primaryIncomeAccount);
+    writer.write(obj.primaryOutcomeAccount);
+    writer.write(obj.primaryTransferFromAccount);
+    writer.write(obj.primaryTransferToAccount);
+    writer.write(obj.primaryInvestmentFromAccount);
+    writer.write(obj.primaryInvestmentToAccount);
   }
 }

--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -17,18 +17,6 @@ class Account extends HiveObject {
   late String accountType;
   @HiveField(2)
   late String bankBalance;
-  /*@HiveField(3)
-  late bool primaryIncomeAccount;
-  @HiveField(4)
-  late bool primaryOutcomeAccount;
-  @HiveField(5)
-  late bool primaryTransferFromAccount;
-  @HiveField(6)
-  late bool primaryTransferToAccount;
-  @HiveField(7)
-  late bool primaryInvestmentFromAccount;
-  @HiveField(8)
-  late bool primaryInvestmentToAccount;*/
 
   void createAccount(Account newAccount) async {
     var accountBox = await Hive.openBox(accountsBox);

--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -1,8 +1,7 @@
-import 'package:haushaltsbuch/models/enums/preselect_account_types.dart';
 import 'package:hive/hive.dart';
 
-import '/models/enums/transaction_types.dart';
 import '/models/enums/account_types.dart';
+import '/models/enums/transaction_types.dart';
 
 import '/utils/consts/hive_consts.dart';
 import '/utils/number_formatters/number_formatter.dart';
@@ -18,7 +17,7 @@ class Account extends HiveObject {
   late String accountType;
   @HiveField(2)
   late String bankBalance;
-  @HiveField(3)
+  /*@HiveField(3)
   late bool primaryIncomeAccount;
   @HiveField(4)
   late bool primaryOutcomeAccount;
@@ -29,7 +28,7 @@ class Account extends HiveObject {
   @HiveField(7)
   late bool primaryInvestmentFromAccount;
   @HiveField(8)
-  late bool primaryInvestmentToAccount;
+  late bool primaryInvestmentToAccount;*/
 
   void createAccount(Account newAccount) async {
     var accountBox = await Hive.openBox(accountsBox);
@@ -251,62 +250,6 @@ class Account extends HiveObject {
     return accountTypeBalanceMap;
   }
 
-  static Future<String> loadPreselectedAccountNameFor(String preselectedAccountType) async {
-    var accountBox = await Hive.openBox(accountsBox);
-    for (int i = 0; i < accountBox.length; i++) {
-      Account account = await accountBox.getAt(i);
-      if (preselectedAccountType == PreselectAccountType.income.name && account.primaryIncomeAccount) {
-        return account.name;
-      }
-      if (preselectedAccountType == PreselectAccountType.outcome.name && account.primaryOutcomeAccount) {
-        return account.name;
-      }
-      if (preselectedAccountType == PreselectAccountType.transferFrom.name && account.primaryTransferFromAccount) {
-        return account.name;
-      }
-      if (preselectedAccountType == PreselectAccountType.transferTo.name && account.primaryTransferToAccount) {
-        return account.name;
-      }
-      if (preselectedAccountType == PreselectAccountType.investmentFrom.name && account.primaryInvestmentFromAccount) {
-        return account.name;
-      }
-      if (preselectedAccountType == PreselectAccountType.investmentTo.name && account.primaryInvestmentToAccount) {
-        return account.name;
-      }
-    }
-    return '';
-  }
-
-  static Future<Map<String, String>> loadCurrentPreselectedAccountNames() async {
-    var accountBox = await Hive.openBox(accountsBox);
-    Map<String, String> primaryAccountNames = {};
-    for (int i = 0; i < accountBox.length; i++) {
-      Account account = await accountBox.getAt(i);
-      if (account.primaryIncomeAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.income.name: account.name});
-      }
-      if (account.primaryOutcomeAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.outcome.name: account.name});
-      }
-      if (account.primaryTransferFromAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.transferFrom.name: account.name});
-      }
-      if (account.primaryTransferToAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.transferTo.name: account.name});
-      }
-      if (account.primaryInvestmentFromAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.investmentFrom.name: account.name});
-      }
-      if (account.primaryInvestmentToAccount) {
-        primaryAccountNames.addAll({PreselectAccountType.investmentTo.name: account.name});
-      }
-      if (primaryAccountNames.length == 6) {
-        break;
-      }
-    }
-    return primaryAccountNames;
-  }
-
   static void createStartAccounts() async {
     var accountBox = await Hive.openBox(accountsBox);
     if (accountBox.isNotEmpty) {
@@ -315,46 +258,22 @@ class Account extends HiveObject {
     Account cashAccount = Account()
       ..name = 'Geldbeutel'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.cash.name
-      ..primaryIncomeAccount = false
-      ..primaryOutcomeAccount = false
-      ..primaryTransferFromAccount = false
-      ..primaryTransferToAccount = false
-      ..primaryInvestmentFromAccount = false
-      ..primaryInvestmentToAccount = false;
+      ..accountType = AccountType.cash.name;
     cashAccount.createAccount(cashAccount);
     Account giroAccount = Account()
       ..name = 'Girokonto'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.account.name
-      ..primaryIncomeAccount = false
-      ..primaryOutcomeAccount = false
-      ..primaryTransferFromAccount = false
-      ..primaryTransferToAccount = false
-      ..primaryInvestmentFromAccount = false
-      ..primaryInvestmentToAccount = false;
+      ..accountType = AccountType.account.name;
     giroAccount.createAccount(giroAccount);
     Account billingAccount = Account()
       ..name = 'Verechnungskonto'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.account.name
-      ..primaryIncomeAccount = false
-      ..primaryOutcomeAccount = false
-      ..primaryTransferFromAccount = false
-      ..primaryTransferToAccount = false
-      ..primaryInvestmentFromAccount = false
-      ..primaryInvestmentToAccount = false;
+      ..accountType = AccountType.account.name;
     billingAccount.createAccount(billingAccount);
     Account capitalInvestmentAccount = Account()
       ..name = 'Aktiendepot'
       ..bankBalance = '0 €'
-      ..accountType = AccountType.capitalInvestments.name
-      ..primaryIncomeAccount = false
-      ..primaryOutcomeAccount = false
-      ..primaryTransferFromAccount = false
-      ..primaryTransferToAccount = false
-      ..primaryInvestmentFromAccount = false
-      ..primaryInvestmentToAccount = false;
+      ..accountType = AccountType.capitalInvestments.name;
     capitalInvestmentAccount.createAccount(capitalInvestmentAccount);
   }
 }
@@ -368,13 +287,7 @@ class AccountAdapter extends TypeAdapter<Account> {
     return Account()
       ..name = reader.read()
       ..accountType = reader.read()
-      ..bankBalance = reader.read()
-      ..primaryIncomeAccount = reader.read()
-      ..primaryOutcomeAccount = reader.read()
-      ..primaryTransferFromAccount = reader.read()
-      ..primaryTransferToAccount = reader.read()
-      ..primaryInvestmentFromAccount = reader.read()
-      ..primaryInvestmentToAccount = reader.read();
+      ..bankBalance = reader.read();
   }
 
   @override
@@ -382,11 +295,5 @@ class AccountAdapter extends TypeAdapter<Account> {
     writer.write(obj.name);
     writer.write(obj.accountType);
     writer.write(obj.bankBalance);
-    writer.write(obj.primaryIncomeAccount);
-    writer.write(obj.primaryOutcomeAccount);
-    writer.write(obj.primaryTransferFromAccount);
-    writer.write(obj.primaryTransferToAccount);
-    writer.write(obj.primaryInvestmentFromAccount);
-    writer.write(obj.primaryInvestmentToAccount);
   }
 }

--- a/lib/models/enums/preselect_account_types.dart
+++ b/lib/models/enums/preselect_account_types.dart
@@ -8,13 +8,13 @@ extension PreselectAccountTypeExtension on PreselectAccountType {
       case PreselectAccountType.outcome:
         return 'Ausgabe';
       case PreselectAccountType.transferFrom:
-        return 'Übertrag von';
+        return 'Übertrag von ...';
       case PreselectAccountType.transferTo:
-        return 'Übertrag nach';
+        return 'Übertrag nach ...';
       case PreselectAccountType.investmentFrom:
-        return 'Investition von';
+        return 'Investition von ...';
       case PreselectAccountType.investmentTo:
-        return 'Investition nach';
+        return 'Investition nach ...';
       default:
         throw Exception('$name is not a valid preselect Account type.');
     }

--- a/lib/models/enums/preselect_account_types.dart
+++ b/lib/models/enums/preselect_account_types.dart
@@ -1,0 +1,22 @@
+enum PreselectAccountType { income, outcome, transferFrom, transferTo, investmentFrom, investmentTo }
+
+extension PreselectAccountTypeExtension on PreselectAccountType {
+  String get name {
+    switch (this) {
+      case PreselectAccountType.income:
+        return 'Einnahme';
+      case PreselectAccountType.outcome:
+        return 'Ausgabe';
+      case PreselectAccountType.transferFrom:
+        return 'Übertrag von';
+      case PreselectAccountType.transferTo:
+        return 'Übertrag nach';
+      case PreselectAccountType.investmentFrom:
+        return 'Investition von';
+      case PreselectAccountType.investmentTo:
+        return 'Investition nach';
+      default:
+        throw Exception('$name is not a valid preselect Account type.');
+    }
+  }
+}

--- a/lib/models/enums/transaction_types.dart
+++ b/lib/models/enums/transaction_types.dart
@@ -3,7 +3,7 @@ import 'package:hive/hive.dart';
 import '/utils/consts/hive_consts.dart';
 
 @HiveType(typeId: transactionTypeId)
-enum TransactionType { income, outcome, transfer, investment }
+enum TransactionType { income, outcome, transfer, transferFrom, transferTo, investment, investmentFrom, investmentTo }
 
 extension TransactionTypeExtension on TransactionType {
   String get name {
@@ -14,8 +14,16 @@ extension TransactionTypeExtension on TransactionType {
         return 'Ausgabe';
       case TransactionType.transfer:
         return 'Übertrag';
+      case TransactionType.transferFrom:
+        return 'Übertrag von ...';
+      case TransactionType.transferTo:
+        return 'Übertrag nach ...';
       case TransactionType.investment:
         return 'Investition';
+      case TransactionType.investmentFrom:
+        return 'Investition von ...';
+      case TransactionType.investmentTo:
+        return 'Investition nach ...';
       default:
         throw Exception('$name is not a valid Transaction.');
     }
@@ -29,8 +37,16 @@ extension TransactionTypeExtension on TransactionType {
         return 'Ausgaben';
       case TransactionType.transfer:
         return 'Überträge';
+      case TransactionType.transferFrom:
+        return 'Überträge von ...';
+      case TransactionType.transferTo:
+        return 'Überträge nach ...';
       case TransactionType.investment:
         return 'Investitionen';
+      case TransactionType.investmentFrom:
+        return 'Investitionen von ...';
+      case TransactionType.investmentTo:
+        return 'Investitionen nach ...';
       default:
         throw Exception('$name is not a valid Transaction.');
     }

--- a/lib/models/primary_account.dart
+++ b/lib/models/primary_account.dart
@@ -56,7 +56,7 @@ class PrimaryAccount extends HiveObject {
     List<String> transactionTypeList = transactionTypes.split(', ');
     for (int i = 0; i < primaryAccountBox.length; i++) {
       PrimaryAccount primaryAccount = await primaryAccountBox.getAt(i);
-      if (primaryAccount.accountName == accountName) {
+      if (primaryAccount.accountName == accountName.trim()) {
         PrimaryAccount updatedPrimaryAccount = PrimaryAccount()
           ..accountName = ''
           ..transactionType = primaryAccount.transactionType;
@@ -67,32 +67,32 @@ class PrimaryAccount extends HiveObject {
       PrimaryAccount updatedPrimaryAccount;
       if (transactionTypeList[i] == PreselectAccountType.income.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.income.name;
         primaryAccountBox.putAt(0, updatedPrimaryAccount);
       } else if (transactionTypeList[i] == PreselectAccountType.outcome.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.outcome.name;
         primaryAccountBox.putAt(1, updatedPrimaryAccount);
       } else if (transactionTypeList[i] == PreselectAccountType.transferFrom.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.transferFrom.name;
         primaryAccountBox.putAt(2, updatedPrimaryAccount);
       } else if (transactionTypeList[i] == PreselectAccountType.transferTo.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.transferTo.name;
         primaryAccountBox.putAt(3, updatedPrimaryAccount);
       } else if (transactionTypeList[i] == PreselectAccountType.investmentFrom.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.investmentFrom.name;
         primaryAccountBox.putAt(4, updatedPrimaryAccount);
       } else if (transactionTypeList[i] == PreselectAccountType.investmentTo.name) {
         updatedPrimaryAccount = PrimaryAccount()
-          ..accountName = accountName
+          ..accountName = accountName.trim()
           ..transactionType = PreselectAccountType.investmentTo.name;
         primaryAccountBox.putAt(5, updatedPrimaryAccount);
       }

--- a/lib/models/primary_account.dart
+++ b/lib/models/primary_account.dart
@@ -1,0 +1,79 @@
+import 'package:hive/hive.dart';
+
+import '/utils/consts/hive_consts.dart';
+
+import '/models/enums/transaction_types.dart';
+import 'enums/preselect_account_types.dart';
+
+@HiveType(typeId: primaryAccountTypeId)
+class PrimaryAccount extends HiveObject {
+  late int boxIndex;
+  @HiveField(0)
+  late String accountName;
+  @HiveField(1)
+  late String transactionType;
+
+  void createPrimaryAccount(PrimaryAccount newPrimaryAccount) async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    primaryAccountBox.add(newPrimaryAccount);
+  }
+
+  static Future<Map<String, String>> getCurrentPrimaryAccounts() async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    Map<String, String> primaryAccounts = {};
+    for (int i = 0; i < primaryAccountBox.length; i++) {
+      PrimaryAccount primaryAccount = await primaryAccountBox.getAt(i);
+      primaryAccounts.addAll({primaryAccount.transactionType: primaryAccount.accountName});
+    }
+    return primaryAccounts;
+  }
+
+  static void createStartPrimaryAccounts() async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    if (primaryAccountBox.isNotEmpty) {
+      return;
+    }
+    PrimaryAccount incomePrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.income.name;
+    incomePrimaryAccount.createPrimaryAccount(incomePrimaryAccount);
+    PrimaryAccount outcomePrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.outcome.name;
+    outcomePrimaryAccount.createPrimaryAccount(outcomePrimaryAccount);
+    PrimaryAccount transferFromPrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.transferFrom.name;
+    transferFromPrimaryAccount.createPrimaryAccount(transferFromPrimaryAccount);
+    PrimaryAccount transferToPrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.transferTo.name;
+    transferToPrimaryAccount.createPrimaryAccount(transferToPrimaryAccount);
+    PrimaryAccount investmentFromPrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.investmentFrom.name;
+    investmentFromPrimaryAccount.createPrimaryAccount(investmentFromPrimaryAccount);
+    PrimaryAccount investmentToPrimaryAccount = PrimaryAccount()
+      ..accountName = ''
+      ..transactionType = TransactionType.investmentTo.name;
+    investmentToPrimaryAccount.createPrimaryAccount(investmentToPrimaryAccount);
+  }
+}
+
+class PrimaryAccountAdapter extends TypeAdapter<PrimaryAccount> {
+  @override
+  final typeId = primaryAccountTypeId;
+
+  @override
+  PrimaryAccount read(BinaryReader reader) {
+    return PrimaryAccount()
+      ..accountName = reader.read()
+      ..transactionType = reader.read();
+  }
+
+  @override
+  void write(BinaryWriter writer, PrimaryAccount obj) {
+    writer.write(obj.accountName);
+    writer.write(obj.transactionType);
+  }
+}

--- a/lib/models/primary_account.dart
+++ b/lib/models/primary_account.dart
@@ -2,8 +2,7 @@ import 'package:hive/hive.dart';
 
 import '/utils/consts/hive_consts.dart';
 
-import '/models/enums/transaction_types.dart';
-import 'enums/preselect_account_types.dart';
+import '/models/enums/preselect_account_types.dart';
 
 @HiveType(typeId: primaryAccountTypeId)
 class PrimaryAccount extends HiveObject {
@@ -18,6 +17,30 @@ class PrimaryAccount extends HiveObject {
     primaryAccountBox.add(newPrimaryAccount);
   }
 
+  static Future<List<PrimaryAccount>> loadPrimaryAccountList() async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    List<PrimaryAccount> primaryAccountList = [];
+    for (int i = 0; i < primaryAccountBox.length; i++) {
+      PrimaryAccount primaryAccount = await primaryAccountBox.getAt(i);
+      primaryAccount.boxIndex = i;
+      primaryAccountList.add(primaryAccount);
+    }
+    return primaryAccountList;
+  }
+
+  static Future<List<PrimaryAccount>> loadFilteredPrimaryAccountList(String accountName) async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    List<PrimaryAccount> primaryAccountList = [];
+    for (int i = 0; i < primaryAccountBox.length; i++) {
+      PrimaryAccount primaryAccount = await primaryAccountBox.getAt(i);
+      if (primaryAccount.accountName == accountName) {
+        primaryAccount.boxIndex = i;
+        primaryAccountList.add(primaryAccount);
+      }
+    }
+    return primaryAccountList;
+  }
+
   static Future<Map<String, String>> getCurrentPrimaryAccounts() async {
     var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
     Map<String, String> primaryAccounts = {};
@@ -28,6 +51,54 @@ class PrimaryAccount extends HiveObject {
     return primaryAccounts;
   }
 
+  static void setPrimaryAccountNames(String transactionTypes, String accountName) async {
+    var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
+    List<String> transactionTypeList = transactionTypes.split(', ');
+    for (int i = 0; i < primaryAccountBox.length; i++) {
+      PrimaryAccount primaryAccount = await primaryAccountBox.getAt(i);
+      if (primaryAccount.accountName == accountName) {
+        PrimaryAccount updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = ''
+          ..transactionType = primaryAccount.transactionType;
+        primaryAccountBox.putAt(i, updatedPrimaryAccount);
+      }
+    }
+    for (int i = 0; i < transactionTypeList.length; i++) {
+      PrimaryAccount updatedPrimaryAccount;
+      if (transactionTypeList[i] == PreselectAccountType.income.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.income.name;
+        primaryAccountBox.putAt(0, updatedPrimaryAccount);
+      } else if (transactionTypeList[i] == PreselectAccountType.outcome.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.outcome.name;
+        primaryAccountBox.putAt(1, updatedPrimaryAccount);
+      } else if (transactionTypeList[i] == PreselectAccountType.transferFrom.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.transferFrom.name;
+        primaryAccountBox.putAt(2, updatedPrimaryAccount);
+      } else if (transactionTypeList[i] == PreselectAccountType.transferTo.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.transferTo.name;
+        primaryAccountBox.putAt(3, updatedPrimaryAccount);
+      } else if (transactionTypeList[i] == PreselectAccountType.investmentFrom.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.investmentFrom.name;
+        primaryAccountBox.putAt(4, updatedPrimaryAccount);
+      } else if (transactionTypeList[i] == PreselectAccountType.investmentTo.name) {
+        updatedPrimaryAccount = PrimaryAccount()
+          ..accountName = accountName
+          ..transactionType = PreselectAccountType.investmentTo.name;
+        primaryAccountBox.putAt(5, updatedPrimaryAccount);
+      }
+    }
+  }
+
   static void createStartPrimaryAccounts() async {
     var primaryAccountBox = await Hive.openBox(primaryAccountsBox);
     if (primaryAccountBox.isNotEmpty) {
@@ -35,27 +106,27 @@ class PrimaryAccount extends HiveObject {
     }
     PrimaryAccount incomePrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.income.name;
+      ..transactionType = PreselectAccountType.income.name;
     incomePrimaryAccount.createPrimaryAccount(incomePrimaryAccount);
     PrimaryAccount outcomePrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.outcome.name;
+      ..transactionType = PreselectAccountType.outcome.name;
     outcomePrimaryAccount.createPrimaryAccount(outcomePrimaryAccount);
     PrimaryAccount transferFromPrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.transferFrom.name;
+      ..transactionType = PreselectAccountType.transferFrom.name;
     transferFromPrimaryAccount.createPrimaryAccount(transferFromPrimaryAccount);
     PrimaryAccount transferToPrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.transferTo.name;
+      ..transactionType = PreselectAccountType.transferTo.name;
     transferToPrimaryAccount.createPrimaryAccount(transferToPrimaryAccount);
     PrimaryAccount investmentFromPrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.investmentFrom.name;
+      ..transactionType = PreselectAccountType.investmentFrom.name;
     investmentFromPrimaryAccount.createPrimaryAccount(investmentFromPrimaryAccount);
     PrimaryAccount investmentToPrimaryAccount = PrimaryAccount()
       ..accountName = ''
-      ..transactionType = TransactionType.investmentTo.name;
+      ..transactionType = PreselectAccountType.investmentTo.name;
     investmentToPrimaryAccount.createPrimaryAccount(investmentToPrimaryAccount);
   }
 }

--- a/lib/screens/budgets_screen.dart
+++ b/lib/screens/budgets_screen.dart
@@ -66,7 +66,7 @@ class _BudgetsScreenState extends State<BudgetsScreen> {
                 Padding(
                   padding: const EdgeInsets.only(right: 12.0),
                   child: DateTime.now().month == _selectedDate.month
-                      ? Text('Restliche Tage: ${DateTime(_selectedDate.year, _selectedDate.month + 1, 0).day - DateTime.now().day}')
+                      ? Text('Restliche Tage: ${DateTime(_selectedDate.year, _selectedDate.month + 1, 0).day - DateTime.now().day + 1}')
                       : const SizedBox(),
                 ),
               ],

--- a/lib/screens/create_or_edit_account_screen.dart
+++ b/lib/screens/create_or_edit_account_screen.dart
@@ -8,6 +8,7 @@ import '/components/deco/loading_indicator.dart';
 import '/components/input_fields/account_type_input_field.dart';
 import '/components/input_fields/money_input_field.dart';
 import '/components/input_fields/text_input_field.dart';
+import '/components/input_fields/preselect_account_input_field.dart';
 import '/components/buttons/save_button.dart';
 
 import '/models/account.dart';
@@ -35,6 +36,7 @@ class CreateOrEditAccountScreen extends StatefulWidget {
 class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
   final TextEditingController _accountGroupTextController = TextEditingController();
   final TextEditingController _bankBalanceTextController = TextEditingController();
+  final TextEditingController _preselectedAccountTextController = TextEditingController();
   final RoundedLoadingButtonController _saveButtonController = RoundedLoadingButtonController();
   bool _isAccountEdited = false;
   final Account _account = Account();
@@ -227,6 +229,7 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
                         TextInputField(input: _accountName, inputCallback: _setAccountNameState, errorText: _accountNameErrorText, hintText: 'Name'),
                         MoneyInputField(
                             textController: _bankBalanceTextController, errorText: _bankBalanceErrorText, hintText: 'Kontostand', bottomSheetTitle: 'Kontostand eingeben:'),
+                        PreselectAccountInputField(textController: _preselectedAccountTextController),
                         SaveButton(saveFunction: _createOrUpdateAccount, buttonController: _saveButtonController),
                       ],
                     );

--- a/lib/screens/create_or_edit_account_screen.dart
+++ b/lib/screens/create_or_edit_account_screen.dart
@@ -15,6 +15,7 @@ import '/models/account.dart';
 import '/models/booking.dart';
 import '/models/enums/repeat_types.dart';
 import '/models/enums/transaction_types.dart';
+import '/models/enums/preselect_account_types.dart';
 import '/models/screen_arguments/bottom_nav_bar_screen_arguments.dart';
 
 import '/utils/consts/route_consts.dart';
@@ -61,6 +62,7 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
     _accountGroupTextController.text = _loadedAccount.accountType;
     _bankBalanceTextController.text = _loadedAccount.bankBalance;
     _oldBankBalance = formatMoneyAmountToDouble(_loadedAccount.bankBalance);
+    _getPrimaryAccounts();
     _isAccountEdited = true;
   }
 
@@ -74,6 +76,7 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
     } else {
       _account.accountType = _accountGroupTextController.text;
       _account.bankBalance = _bankBalanceTextController.text;
+      _setPrimaryAccounts();
       if (widget.accountBoxIndex == -1) {
         _account.createAccount(_account);
         _navigateToAccountScreen();
@@ -195,6 +198,45 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
         Navigator.pushNamed(context, bottomNavBarRoute, arguments: BottomNavBarScreenArguments(2));
       }
     });
+  }
+
+  void _setPrimaryAccounts() {
+    _preselectedAccountTextController.text.contains(PreselectAccountType.income.name) ? _account.primaryIncomeAccount = true : _account.primaryIncomeAccount = false;
+    _preselectedAccountTextController.text.contains(PreselectAccountType.outcome.name) ? _account.primaryOutcomeAccount = true : _account.primaryOutcomeAccount = false;
+    _preselectedAccountTextController.text.contains(PreselectAccountType.transferFrom.name)
+        ? _account.primaryTransferFromAccount = true
+        : _account.primaryTransferFromAccount = false;
+    _preselectedAccountTextController.text.contains(PreselectAccountType.transferTo.name) ? _account.primaryTransferToAccount = true : _account.primaryTransferToAccount = false;
+    _preselectedAccountTextController.text.contains(PreselectAccountType.investmentFrom.name)
+        ? _account.primaryInvestmentFromAccount = true
+        : _account.primaryInvestmentFromAccount = false;
+    _preselectedAccountTextController.text.contains(PreselectAccountType.investmentTo.name)
+        ? _account.primaryInvestmentToAccount = true
+        : _account.primaryInvestmentToAccount = false;
+  }
+
+  void _getPrimaryAccounts() {
+    if (_loadedAccount.primaryIncomeAccount) {
+      _preselectedAccountTextController.text = PreselectAccountType.income.name;
+    }
+    if (_loadedAccount.primaryOutcomeAccount) {
+      _preselectedAccountTextController.text += _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.outcome.name : ', ' + PreselectAccountType.outcome.name;
+    }
+    if (_loadedAccount.primaryTransferFromAccount) {
+      _preselectedAccountTextController.text +=
+          _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.transferFrom.name : ', ' + PreselectAccountType.transferFrom.name;
+    }
+    if (_loadedAccount.primaryTransferToAccount) {
+      _preselectedAccountTextController.text += _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.transferTo.name : ', ' + PreselectAccountType.transferTo.name;
+    }
+    if (_loadedAccount.primaryInvestmentFromAccount) {
+      _preselectedAccountTextController.text +=
+          _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.investmentFrom.name : ', ' + PreselectAccountType.investmentFrom.name;
+    }
+    if (_loadedAccount.primaryInvestmentToAccount) {
+      _preselectedAccountTextController.text +=
+          _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.investmentTo.name : ', ' + PreselectAccountType.investmentTo.name;
+    }
   }
 
   @override

--- a/lib/screens/create_or_edit_account_screen.dart
+++ b/lib/screens/create_or_edit_account_screen.dart
@@ -13,6 +13,7 @@ import '/components/buttons/save_button.dart';
 
 import '/models/account.dart';
 import '/models/booking.dart';
+import '/models/primary_account.dart';
 import '/models/enums/repeat_types.dart';
 import '/models/enums/transaction_types.dart';
 import '/models/enums/preselect_account_types.dart';
@@ -46,6 +47,7 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
   String _accountGroupErrorText = '';
   String _bankBalanceErrorText = '';
   late Account _loadedAccount;
+  late Map<String, String> _loadedPrimaryAccounts;
   double _oldBankBalance = 0.0;
 
   @override
@@ -201,22 +203,28 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
   }
 
   void _setPrimaryAccounts() {
-    _preselectedAccountTextController.text.contains(PreselectAccountType.income.name) ? _account.primaryIncomeAccount = true : _account.primaryIncomeAccount = false;
-    _preselectedAccountTextController.text.contains(PreselectAccountType.outcome.name) ? _account.primaryOutcomeAccount = true : _account.primaryOutcomeAccount = false;
-    _preselectedAccountTextController.text.contains(PreselectAccountType.transferFrom.name)
-        ? _account.primaryTransferFromAccount = true
-        : _account.primaryTransferFromAccount = false;
-    _preselectedAccountTextController.text.contains(PreselectAccountType.transferTo.name) ? _account.primaryTransferToAccount = true : _account.primaryTransferToAccount = false;
-    _preselectedAccountTextController.text.contains(PreselectAccountType.investmentFrom.name)
-        ? _account.primaryInvestmentFromAccount = true
-        : _account.primaryInvestmentFromAccount = false;
-    _preselectedAccountTextController.text.contains(PreselectAccountType.investmentTo.name)
-        ? _account.primaryInvestmentToAccount = true
-        : _account.primaryInvestmentToAccount = false;
+    if (_preselectedAccountTextController.text.contains(PreselectAccountType.income.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.income.name] = _accountName;
+    } else if (_preselectedAccountTextController.text.contains(PreselectAccountType.outcome.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.outcome.name] = _accountName;
+    } else if (_preselectedAccountTextController.text.contains(PreselectAccountType.transferFrom.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.transferFrom.name] = _accountName;
+    } else if (_preselectedAccountTextController.text.contains(PreselectAccountType.transferTo.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.transferTo.name] = _accountName;
+    } else if (_preselectedAccountTextController.text.contains(PreselectAccountType.investmentFrom.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.investmentFrom.name] = _accountName;
+    } else if (_preselectedAccountTextController.text.contains(PreselectAccountType.investmentTo.name)) {
+      _loadedPrimaryAccounts[PreselectAccountType.investmentTo.name] = _accountName;
+    }
   }
 
+  // TODO hier weitermachen und _loadedPrimaryAccounts Map mithilfe der Funktion getCurrentPrimaryAccounts befüllen.
   void _getPrimaryAccounts() {
-    if (_loadedAccount.primaryIncomeAccount) {
+    Iterable<Object> primaryAccounts = _loadedPrimaryAccounts.values;
+    for (final primaryAccount in primaryAccounts) {
+      _preselectedAccountTextController.text = primaryAccount.toString() + ', ';
+    }
+    /*if (_loadedPrimaryAccounts) {
       _preselectedAccountTextController.text = PreselectAccountType.income.name;
     }
     if (_loadedAccount.primaryOutcomeAccount) {
@@ -236,7 +244,7 @@ class _CreateOrEditAccountScreenState extends State<CreateOrEditAccountScreen> {
     if (_loadedAccount.primaryInvestmentToAccount) {
       _preselectedAccountTextController.text +=
           _preselectedAccountTextController.text.isEmpty ? PreselectAccountType.investmentTo.name : ', ' + PreselectAccountType.investmentTo.name;
-    }
+    }*/
   }
 
   @override

--- a/lib/screens/create_or_edit_booking_screen.dart
+++ b/lib/screens/create_or_edit_booking_screen.dart
@@ -280,34 +280,47 @@ class _CreateOrEditBookingScreenState extends State<CreateOrEditBookingScreen> {
     _isPreselectedAccountsLoaded = true;
   }
 
-  // TODO hier weitermachen beim Laden wird das Konto nicht geladen => Grund: _fromAccountTextController.text muss
-  // TODO nur bei bestimmten Bedingungen gesetzt werden Beispiel: if (widget.bookingBoxIndex != -1) {...} dann nicht setzen
-  // sondern _loadedBooking Werte setzen!
   Widget _getAccountInputField() {
-    if (_currentTransaction == TransactionType.income.name) {
-      _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.income.name] ?? '';
-      return AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText);
-    } else if (_currentTransaction == TransactionType.outcome.name) {
-      _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.outcome.name] ?? '';
-      return AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText);
-    } else if (_currentTransaction == TransactionType.transfer.name) {
-      _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.transferFrom.name] ?? '';
-      _toAccountTextController.text = _primaryAccounts[PreselectAccountType.transferTo.name] ?? '';
-      return Column(
-        children: [
-          AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von'),
-          AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach')
-        ],
-      );
-    } else if (_currentTransaction == TransactionType.investment.name) {
-      _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.investmentFrom.name] ?? '';
-      _toAccountTextController.text = _primaryAccounts[PreselectAccountType.investmentTo.name] ?? '';
-      return Column(
-        children: [
-          AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von'),
-          AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach'),
-        ],
-      );
+    if (widget.bookingBoxIndex == -1) {
+      if (_currentTransaction == TransactionType.income.name) {
+        _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.income.name] ?? '';
+        return AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText);
+      } else if (_currentTransaction == TransactionType.outcome.name) {
+        _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.outcome.name] ?? '';
+        return AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText);
+      } else if (_currentTransaction == TransactionType.transfer.name) {
+        _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.transferFrom.name] ?? '';
+        _toAccountTextController.text = _primaryAccounts[PreselectAccountType.transferTo.name] ?? '';
+        return Column(
+          children: [
+            AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von'),
+            AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach')
+          ],
+        );
+      } else if (_currentTransaction == TransactionType.investment.name) {
+        _fromAccountTextController.text = _primaryAccounts[PreselectAccountType.investmentFrom.name] ?? '';
+        _toAccountTextController.text = _primaryAccounts[PreselectAccountType.investmentTo.name] ?? '';
+        return Column(
+          children: [
+            AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von'),
+            AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach'),
+          ],
+        );
+      }
+    } else {
+      if (_currentTransaction == TransactionType.income.name || _currentTransaction == TransactionType.outcome.name) {
+        _fromAccountTextController.text = _loadedBooking.fromAccount;
+        return AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText);
+      } else {
+        _fromAccountTextController.text = _loadedBooking.fromAccount;
+        _toAccountTextController.text = _loadedBooking.toAccount;
+        return Column(
+          children: [
+            AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von'),
+            AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach'),
+          ],
+        );
+      }
     }
     return const SizedBox();
   }

--- a/lib/screens/create_or_edit_booking_screen.dart
+++ b/lib/screens/create_or_edit_booking_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:another_flushbar/flushbar.dart';
 import 'package:rounded_loading_button/rounded_loading_button.dart';
 
+import '../models/enums/preselect_account_types.dart';
 import '/utils/consts/route_consts.dart';
 import '/utils/consts/global_consts.dart';
 import '/utils/date_formatters/date_formatter.dart';
@@ -271,6 +272,52 @@ class _CreateOrEditBookingScreenState extends State<CreateOrEditBookingScreen> {
     FocusScope.of(context).unfocus();
   }
 
+  // TODO hier weitermachen und richtige vorselektierte Konten anzeigen lassen
+  Widget _getAccountInputField() {
+    if (_currentTransaction == TransactionType.income.name) {
+      return AccountInputField(
+          textController: _fromAccountTextController, errorText: _fromAccountErrorText, checkPreselectedAccount: true, preselectedAccountType: PreselectAccountType.income.name);
+    } else if (_currentTransaction == TransactionType.outcome.name) {
+      return AccountInputField(
+          textController: _fromAccountTextController, errorText: _fromAccountErrorText, checkPreselectedAccount: true, preselectedAccountType: PreselectAccountType.outcome.name);
+    } else if (_currentTransaction == TransactionType.transfer.name) {
+      return Column(
+        children: [
+          AccountInputField(
+              textController: _fromAccountTextController,
+              errorText: _fromAccountErrorText,
+              hintText: 'Von',
+              checkPreselectedAccount: true,
+              preselectedAccountType: PreselectAccountType.transferFrom.name),
+          AccountInputField(
+              textController: _fromAccountTextController,
+              errorText: _fromAccountErrorText,
+              hintText: 'Nach',
+              checkPreselectedAccount: true,
+              preselectedAccountType: PreselectAccountType.transferTo.name)
+        ],
+      );
+    } else if (_currentTransaction == TransactionType.investment.name) {
+      return Column(
+        children: [
+          AccountInputField(
+              textController: _fromAccountTextController,
+              errorText: _fromAccountErrorText,
+              hintText: 'Von',
+              checkPreselectedAccount: true,
+              preselectedAccountType: PreselectAccountType.investmentFrom.name),
+          AccountInputField(
+              textController: _fromAccountTextController,
+              errorText: _fromAccountErrorText,
+              hintText: 'Nach',
+              checkPreselectedAccount: true,
+              preselectedAccountType: PreselectAccountType.investmentTo.name)
+        ],
+      );
+    }
+    return const SizedBox();
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -319,15 +366,10 @@ class _CreateOrEditBookingScreenState extends State<CreateOrEditBookingScreen> {
                             repeatCallback: (repeat) => setState(() => _bookingRepeat = repeat)),
                         TextInputField(input: _title, inputCallback: _setTitleState, hintText: 'Titel'),
                         MoneyInputField(textController: _amountTextController, errorText: _amountErrorText, hintText: 'Betrag', bottomSheetTitle: 'Betrag eingeben:'),
+                        _getAccountInputField(),
                         _currentTransaction == TransactionType.transfer.name
                             ? const SizedBox()
                             : CategorieInputField(textController: _categorieTextController, errorText: _categorieErrorText, transactionType: _currentTransaction),
-                        _currentTransaction == TransactionType.transfer.name || _currentTransaction == TransactionType.investment.name
-                            ? AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText, hintText: 'Von')
-                            : AccountInputField(textController: _fromAccountTextController, errorText: _fromAccountErrorText),
-                        _currentTransaction == TransactionType.transfer.name || _currentTransaction == TransactionType.investment.name
-                            ? AccountInputField(textController: _toAccountTextController, errorText: _toAccountErrorText, hintText: 'Nach')
-                            : const SizedBox(),
                         SaveButton(saveFunction: _createOrUpdateBooking, buttonController: _saveButtonController),
                       ],
                     );

--- a/lib/screens/introduction_screens.dart
+++ b/lib/screens/introduction_screens.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:introduction_screen/introduction_screen.dart';
 
 import '../models/global_state.dart';
+import '../models/primary_account.dart';
 import '/models/account.dart';
 import '/models/categorie.dart';
 import '/models/screen_arguments/bottom_nav_bar_screen_arguments.dart';
@@ -35,6 +36,7 @@ class _IntroductionScreensState extends State<IntroductionScreens> {
     Categorie.createStartRevenueCategories();
     Categorie.createStartInvestmentCategories();
     Account.createStartAccounts();
+    PrimaryAccount.createStartPrimaryAccounts();
     GlobalState.createGlobalState();
     Navigator.popAndPushNamed(context, bottomNavBarRoute, arguments: BottomNavBarScreenArguments(0));
   }
@@ -88,9 +90,7 @@ class _IntroductionScreensState extends State<IntroductionScreens> {
         activeColor: Theme.of(context).colorScheme.secondary,
         color: Colors.white,
         spacing: const EdgeInsets.symmetric(horizontal: 3.0),
-        activeShape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(25.0)
-        ),
+        activeShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(25.0)),
       ),
       baseBtnStyle: TextButton.styleFrom(
         backgroundColor: Colors.cyanAccent,

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:haushaltsbuch/components/deco/loading_indicator.dart';
-import 'package:haushaltsbuch/screens/introduction_screens.dart';
 
-import '../components/bottom_nav_bar/bottom_nav_bar.dart';
-import '../models/account.dart';
-import '../models/categorie.dart';
-import '../models/global_state.dart';
+import '/screens/introduction_screens.dart';
+
+import '/components/deco/loading_indicator.dart';
+import '/components/bottom_nav_bar/bottom_nav_bar.dart';
+
+import '/models/account.dart';
+import '/models/categorie.dart';
+import '/models/global_state.dart';
+import '/models/primary_account.dart';
 import '/models/intro_screen_state.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -57,6 +60,7 @@ class _SplashScreenState extends State<SplashScreen> {
                     Categorie.createStartRevenueCategories();
                     Categorie.createStartInvestmentCategories();
                     Account.createStartAccounts();
+                    PrimaryAccount.createStartPrimaryAccounts();
                     GlobalState.createGlobalState();
                     return const BottomNavBar(screenIndex: 0);
                   }

--- a/lib/utils/consts/hive_consts.dart
+++ b/lib/utils/consts/hive_consts.dart
@@ -3,6 +3,7 @@ import '../settings/settings.dart';
 // Namen der Hive Boxen
 var bookingsBox = demoMode ? 'DEMO_bookings' : 'bookings';
 var accountsBox = demoMode ? 'DEMO_accounts' : 'accounts';
+var primaryAccountsBox = demoMode ? 'DEMO_primaryAccounts' : 'primaryAccounts';
 var categoriesBox = demoMode ? 'DEMO_categories' : 'categories';
 var budgetsBox = demoMode ? 'DEMO_budgets' : 'budgets';
 var defaultBudgetsBox = demoMode ? 'DEMO_defaultBudgets' : 'defaultBudgets';
@@ -20,3 +21,4 @@ const int budgetTypeId = 5;
 const int globalStateTypeId = 6;
 const int defaultBudgetTypeId = 7;
 const int categoryTypeTypeId = 8;
+const int primaryAccountTypeId = 9;


### PR DESCRIPTION
Folgende Implementierungen wurden vorgenommen um Primärkonten auswählen und verwalten zu können:

- Preselect_account_input_field Widget wurde implementiert, um ein Eingabe Widget zur Auswahl von Primärkonten zu haben. Im Bottom Sheet kann dann für jeden Transaktion Typ ein Primärkonto ausgewählt werden (Einnahme, Ausgabe, Übertrag von ..., Übertrag nach ..., Investition von ... und Investition nach ... . Außerdem werden im Bottom Sheet die aktuellen Primärkonten angezeigt, wenn bereits Primärkonten ausgewählt wurden.
- PrimaryAccount Hive Klasse + Adapter und Funktionen zum Laden und Setzen von Primärkonten wurde implementiert, um Primärkonten zu verwalten und abzuspeichern.
- Beim Erstellen einer Buchung wird nun automatisch ein Primärkonto ausgewählt, wenn der Benutzer dieses zuvor definiert hat, wenn kein Primärkonto ausgewählt wurde muss dieses wie bisher manuell vom Benutzer gesetzt werden, wenn er eine Buchung erstellt.
- Beim Start der App wird die Datenstruktur für Primärkonten angelegt wie bei z.B.: Konten auch. Dabei gilt folgende Datenstruktur die in Hive abgespeichert wird:
     - 0: "Einnahme", ""
     - 1: "Ausgabe", ""
     - 2: "Übertrag von ...", ""
     - 3: "Übertrag nach ...", ""
     - 4: "Investition von ...", ""
     - 5: "Investition nach ...", ""
Dabei sind "" die Primärkonten Namen die dann vom Benutzer gesetzt werden können.

Folgende weitere Änderungen wurden implementiert:
- Buchungskarte (BookingCard.dart) UI wurde leicht verbessert => Padding zum rechten Rand der Trennlinie wurde implementiert (8.0). Buchungsbeschreibung linkes Padding zur Trennlinie wurde auf 8.0 verringert.
- Restliche Tage bei Budgetansicht wurde korrigiert (+ 1 Tag).