### PR TITLE
Bugfix Kategoriename ändern

### DIFF
--- a/lib/models/booking.dart
+++ b/lib/models/booking.dart
@@ -275,6 +275,28 @@ class Booking extends HiveObject {
     }
   }
 
+  static Future<void> updateBookingCategorieName(String oldCategorieName, String newCategorieName) async {
+    var bookingBox = await Hive.openBox(bookingsBox);
+    for (int i = 0; i < bookingBox.length; i++) {
+      Booking booking = await bookingBox.getAt(i);
+      if (booking.categorie == oldCategorieName) {
+        Booking updatedBookingWithNewCategorieName = Booking()
+          ..boxIndex = i
+          ..transactionType = booking.transactionType
+          ..bookingRepeats = booking.bookingRepeats
+          ..title = booking.title
+          ..date = booking.date
+          ..amount = booking.amount
+          ..categorie = newCategorieName
+          ..fromAccount = booking.fromAccount
+          ..toAccount = booking.toAccount
+          ..serieId = booking.serieId
+          ..booked = booking.booked;
+        bookingBox.putAt(updatedBookingWithNewCategorieName.boxIndex, updatedBookingWithNewCategorieName);
+      }
+    }
+  }
+
   void deleteBooking(int bookingBoxIndex) async {
     var bookingBox = await Hive.openBox(bookingsBox);
     Booking booking = await bookingBox.getAt(bookingBoxIndex);

--- a/lib/models/categorie.dart
+++ b/lib/models/categorie.dart
@@ -1,6 +1,8 @@
 import 'package:hive/hive.dart';
 
 import '/utils/consts/hive_consts.dart';
+
+import 'booking.dart';
 import 'enums/categorie_types.dart';
 
 @HiveType(typeId: categoryTypeId)
@@ -21,6 +23,7 @@ class Categorie extends HiveObject {
       Categorie categorie = await categorieBox.getAt(i);
       if (oldCategorieName == categorie.name) {
         categorieBox.putAt(i, updatedCategorie);
+        Booking.updateBookingCategorieName(oldCategorieName, updatedCategorie.name);
         break;
       }
     }


### PR DESCRIPTION
- Wenn der Benutzer einen Kategorienamen ändert/bearbeitet, wird bei allen Buchungen der Kategorie Name die, dieser Kategorie zugeordnet sind ebenfalls aktualisiert.