### PR TITLE
Bugfix Kontofeld wird geleert

### DIFF
--- a/lib/screens/create_or_edit_booking_screen.dart
+++ b/lib/screens/create_or_edit_booking_screen.dart
@@ -189,12 +189,10 @@ class _CreateOrEditBookingScreenState extends State<CreateOrEditBookingScreen> {
   }
 
   set currentTransaction(String transaction) => setState(() => {_currentTransaction = transaction, _categorieTextController.text = ''});
-  set currentBookingDate(DateTime bookingDate) => setState(() => _parsedBookingDate = bookingDate);
+  set currentBookingDate(DateTime bookingDate) => _parsedBookingDate = bookingDate;
 
   void _setTitleState(String title) {
-    setState(() {
-      _title = title;
-    });
+    _title = title;
   }
 
   void _deleteBooking(int index) {
@@ -370,7 +368,7 @@ class _CreateOrEditBookingScreenState extends State<CreateOrEditBookingScreen> {
                         DateInputField(
                             currentDate: _parsedBookingDate,
                             textController: _bookingDateTextController,
-                            bookingDateCallback: (bookingDate) => setState(() => _parsedBookingDate = bookingDate),
+                            bookingDateCallback: (bookingDate) => _parsedBookingDate = bookingDate,
                             repeat: _bookingRepeat,
                             repeatCallback: (repeat) => setState(() => _bookingRepeat = repeat)),
                         TextInputField(input: _title, inputCallback: _setTitleState, hintText: 'Titel'),


### PR DESCRIPTION
- Kontofeld wird bei Titel oder Datum verändern nicht mehr gelehrt.
- Wenn der Wiederholungstyp geändert wird, wird das Kontofeld immer noch gelehrt => muss noch behoben werden geht aber nicht nach dem gleichen Muster wie bei Titel oder Datum.