### PR TITLE
Bug bei Betrag eingeben behoben

### DIFF
--- a/lib/components/input_fields/money_input_field.dart
+++ b/lib/components/input_fields/money_input_field.dart
@@ -110,7 +110,7 @@ class MoneyInputField extends StatelessWidget {
                         child: const Text('0', style: TextStyle(color: Colors.cyanAccent, fontSize: 26.0)),
                       ),
                       OutlinedButton(
-                        onPressed: () => _setAmount(','),
+                        onPressed: () => cubit.state.amount.contains(',') ? null : _setAmount(','),
                         child: const Text(',', style: TextStyle(color: Colors.cyanAccent, fontSize: 36.0)),
                       ),
                     ],


### PR DESCRIPTION
- Wenn bei der Betragseingabe 2x hintereinander ein Komma ( , ) eingegeben wurde, wurde die bisherige Betragseingabe gelöscht. Dieser Fehler wurde behoben indem geprüft wird, ob der String bereits ein Komma ( , ) enthält. Wenn der String ein Komma enthält wird nichts gemacht.