### PR TITLE
Budget Karten und Übersicht wurde verbessert

### DIFF
--- a/lib/components/cards/budget_card.dart
+++ b/lib/components/cards/budget_card.dart
@@ -71,70 +71,66 @@ class _BudgetCardState extends State<BudgetCard> {
                 textColor: Colors.white,
                 iconColor: Colors.white,
                 subtitle: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Expanded(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Expanded(
-                            flex: 3,
-                            child: Container(
-                              decoration: BoxDecoration(
-                                border: Border(right: BorderSide(color: Colors.grey.shade700, width: 0.5)),
-                              ),
-                              child: Padding(
-                                padding: const EdgeInsets.only(left: 12.0, top: 14.0, bottom: 14.0),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(widget.budget.categorie, overflow: TextOverflow.ellipsis, maxLines: 2),
-                                    Padding(
-                                      padding: const EdgeInsets.only(top: 2.0),
-                                      child: Text(formatToMoneyAmount(widget.budget.budget.toString()), overflow: TextOverflow.ellipsis),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                          Expanded(
-                            flex: 3,
-                            child: Padding(
-                              padding: const EdgeInsets.only(left: 12.0),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(formatToMoneyAmount((widget.budget.budget - widget.budget.currentExpenditure).abs().toString()), overflow: TextOverflow.ellipsis),
-                                  Padding(
-                                    padding: const EdgeInsets.only(top: 2.0),
-                                    child: widget.budget.budget - widget.budget.currentExpenditure >= 0.0
-                                        ? const Text('noch verfügbar', style: TextStyle(color: Colors.grey))
-                                        : const Text('überschritten', style: TextStyle(color: Colors.grey)),
-                                  ),
-                                ],
+                      flex: 5,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 12.0, top: 4.0, bottom: 4.0, right: 4.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(widget.budget.categorie +
+                                ': ' +
+                                formatToMoneyAmount(widget.budget.currentExpenditure.toString()) +
+                                ' / ' +
+                                formatToMoneyAmount(widget.budget.budget.toString())),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 8.0),
+                              child: LinearPercentIndicator(
+                                padding: EdgeInsets.zero,
+                                width: 200.0,
+                                lineHeight: 14.0,
+                                percent: widget.budget.percentage / 100 >= 1.0 ? 1.0 : widget.budget.percentage / 100,
+                                center: Text('${widget.budget.percentage.toStringAsFixed(0)} %',
+                                    style: const TextStyle(fontSize: 12.0, fontWeight: FontWeight.w500, color: Colors.black87)),
+                                progressColor: widget.budget.percentage < 80.0
+                                    ? Colors.green
+                                    : widget.budget.percentage < 100.0
+                                        ? Colors.yellowAccent.shade700
+                                        : Colors.redAccent,
+                                barRadius: const Radius.circular(20.0),
+                                animation: true,
+                                animateFromLastPercent: true,
+                                animationDuration: 1000,
                               ),
                             ),
-                          ),
-                        ],
+                            Text(
+                              widget.budget.percentage <= 100.0
+                                  ? 'Du kannst noch ' +
+                                      formatToMoneyAmount(((widget.budget.budget - widget.budget.currentExpenditure) /
+                                              (DateTime(widget.selectedDate.year, widget.selectedDate.month + 1, 0).day - DateTime.now().day + 1))
+                                          .toString()) +
+                                      ' / Tag ausgeben'
+                                  : 'Du hast das Budget um ' + formatToMoneyAmount((widget.budget.currentExpenditure - widget.budget.budget).toString()) + ' überzogen',
+                              style: const TextStyle(fontSize: 12.0, color: Colors.grey),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 12.0),
-                      child: CircularPercentIndicator(
-                        radius: 26.0,
-                        lineWidth: 5.0,
-                        percent: widget.budget.percentage / 100 >= 1.0 ? 1.0 : widget.budget.percentage / 100,
-                        center: Text('${widget.budget.percentage.toStringAsFixed(0)} %', style: const TextStyle(fontSize: 12.0)),
-                        progressColor: widget.budget.percentage < 80.0
-                            ? Colors.greenAccent
-                            : widget.budget.percentage < 100.0
-                                ? Colors.yellowAccent.shade700
-                                : Colors.redAccent,
-                        backgroundWidth: 2.2,
-                        circularStrokeCap: CircularStrokeCap.round,
-                        animation: true,
-                        animateFromLastPercent: true,
+                    Expanded(
+                      flex: 1,
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: IconButton(
+                          icon: const Icon(
+                            Icons.bar_chart_rounded,
+                            size: 28.0,
+                          ),
+                          onPressed: () =>
+                              Navigator.pushNamed(context, categorieAmountListRoute, arguments: CategorieAmountListScreenArguments(widget.selectedDate, widget.budget.categorie)),
+                        ),
                       ),
                     ),
                   ],
@@ -148,60 +144,63 @@ class _BudgetCardState extends State<BudgetCard> {
                           return const SizedBox();
                         case ConnectionState.done:
                           return SizedBox(
-                            height: _subcategorieBudgets.length * 58.0,
+                            height: _subcategorieBudgets.length * 80.0,
                             child: ListView.builder(
                               itemCount: _subcategorieBudgets.length,
                               physics: const NeverScrollableScrollPhysics(),
                               itemBuilder: (BuildContext context, int subcategorieIndex) {
                                 return ListTile(
-                                  title: Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  subtitle: Row(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
                                     children: [
-                                      Expanded(
-                                        flex: 2,
-                                        child: Padding(
-                                          padding: const EdgeInsets.only(left: 36.0),
-                                          child: Column(
-                                            crossAxisAlignment: CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                _subcategorieBudgets[subcategorieIndex].subcategorieName,
-                                                style: const TextStyle(fontSize: 14.0),
-                                                overflow: TextOverflow.ellipsis,
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 36.0, top: 4.0, bottom: 4.0, right: 4.0),
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            Text(_subcategorieBudgets[subcategorieIndex].subcategorieName +
+                                                ': ' +
+                                                formatToMoneyAmount(_subcategorieBudgets[subcategorieIndex].currentSubcategorieExpenditure.toString()) +
+                                                ' / ' +
+                                                formatToMoneyAmount(_subcategorieBudgets[subcategorieIndex].subcategorieBudget.toString())),
+                                            Padding(
+                                              padding: const EdgeInsets.symmetric(vertical: 8.0),
+                                              child: LinearPercentIndicator(
+                                                padding: EdgeInsets.zero,
+                                                width: 200.0,
+                                                lineHeight: 14.0,
+                                                percent: _subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage / 100 >= 1.0
+                                                    ? 1.0
+                                                    : _subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage / 100,
+                                                center: Text('${_subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage.toStringAsFixed(0)} %',
+                                                    style: const TextStyle(fontSize: 12.0, color: Colors.black87)),
+                                                progressColor: _subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage < 80.0
+                                                    ? Colors.green
+                                                    : _subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage < 100.0
+                                                        ? Colors.yellowAccent.shade700
+                                                        : Colors.redAccent,
+                                                barRadius: const Radius.circular(20.0),
+                                                animation: true,
+                                                animateFromLastPercent: true,
+                                                animationDuration: 1000,
                                               ),
-                                              Text(
-                                                formatToMoneyAmount(_subcategorieBudgets[subcategorieIndex].subcategorieBudget.toString()),
-                                                style: const TextStyle(fontSize: 14.0),
-                                                overflow: TextOverflow.ellipsis,
-                                              ),
-                                            ],
-                                          ),
-                                        ),
-                                      ),
-                                      Expanded(
-                                        flex: 3,
-                                        child: Padding(
-                                          padding: const EdgeInsets.only(left: 20.0, right: 16.0),
-                                          child: Column(
-                                            crossAxisAlignment: CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                formatToMoneyAmount((_subcategorieBudgets[subcategorieIndex].subcategorieBudget -
-                                                        _subcategorieBudgets[subcategorieIndex].currentSubcategorieExpenditure)
-                                                    .toString()),
-                                                style: const TextStyle(fontSize: 14.0),
-                                                overflow: TextOverflow.ellipsis,
-                                              ),
-                                              Padding(
-                                                padding: const EdgeInsets.only(top: 2.0),
-                                                child: _subcategorieBudgets[subcategorieIndex].subcategorieBudget -
-                                                            _subcategorieBudgets[subcategorieIndex].currentSubcategorieExpenditure >=
-                                                        0.0
-                                                    ? const Text('noch verfügbar', style: TextStyle(color: Colors.grey, fontSize: 14.0))
-                                                    : const Text('überschritten', style: TextStyle(color: Colors.grey, fontSize: 14.0)),
-                                              ),
-                                            ],
-                                          ),
+                                            ),
+                                            Text(
+                                              _subcategorieBudgets[subcategorieIndex].currentSubcategoriePercentage <= 100.0
+                                                  ? 'Du kannst noch ' +
+                                                      formatToMoneyAmount(((_subcategorieBudgets[subcategorieIndex].subcategorieBudget -
+                                                                  _subcategorieBudgets[subcategorieIndex].currentSubcategorieExpenditure) /
+                                                              (DateTime(widget.selectedDate.year, widget.selectedDate.month + 1, 0).day - DateTime.now().day + 1))
+                                                          .toString()) +
+                                                      ' / Tag ausgeben'
+                                                  : 'Du hast dein Budget um ' +
+                                                      formatToMoneyAmount((_subcategorieBudgets[subcategorieIndex].currentSubcategorieExpenditure -
+                                                              _subcategorieBudgets[subcategorieIndex].subcategorieBudget)
+                                                          .toString()) +
+                                                      ' überschritten',
+                                              style: const TextStyle(fontSize: 12.0, color: Colors.grey),
+                                            ),
+                                          ],
                                         ),
                                       ),
                                     ],

--- a/lib/screens/budget_screens/budgets_screen.dart
+++ b/lib/screens/budget_screens/budgets_screen.dart
@@ -69,7 +69,7 @@ class _BudgetsScreenState extends State<BudgetsScreen> {
                 Padding(
                   padding: const EdgeInsets.only(right: 12.0),
                   child: DateTime.now().month == _selectedDate.month
-                      ? Text('Verbleibende Tage: ${DateTime(_selectedDate.year, _selectedDate.month + 1, 0).day - DateTime.now().day + 1}')
+                      ? Text('Restliche Tage: ${DateTime(_selectedDate.year, _selectedDate.month + 1, 0).day - DateTime.now().day + 1}')
                       : const SizedBox(),
                 ),
               ],
@@ -100,32 +100,51 @@ class _BudgetsScreenState extends State<BudgetsScreen> {
                                 ),
                                 child: SingleChildScrollView(
                                   physics: const NeverScrollableScrollPhysics(),
-                                  child: CircularPercentIndicator(
-                                    radius: 84.0,
-                                    lineWidth: 10.0,
-                                    percent: _completeBudgetPercentage / 100 >= 1.0 ? 1.0 : _completeBudgetPercentage / 100,
-                                    center: Text('${_completeBudgetPercentage.toStringAsFixed(1)} %', style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
-                                    header: Padding(
-                                      padding: const EdgeInsets.symmetric(vertical: 12.0),
-                                      child: Text('${formatToMoneyAmount(_completeBudgetExpenditures.toString())} / ${formatToMoneyAmount(_completeBudgetAmount.toString())}',
-                                          style: const TextStyle(fontSize: 16.0)),
-                                    ),
-                                    progressColor: _completeBudgetPercentage < 80.0
-                                        ? Colors.greenAccent
-                                        : _completeBudgetPercentage < 100.0
-                                            ? Colors.yellowAccent.shade700
-                                            : Colors.redAccent,
-                                    arcType: ArcType.HALF,
-                                    circularStrokeCap: CircularStrokeCap.round,
-                                    arcBackgroundColor: Colors.grey,
-                                    animation: true,
-                                    animateFromLastPercent: true,
+                                  child: Column(
+                                    children: [
+                                      CircularPercentIndicator(
+                                        radius: 84.0,
+                                        lineWidth: 12.0,
+                                        percent: _completeBudgetPercentage / 100 >= 1.0 ? 1.0 : _completeBudgetPercentage / 100,
+                                        center: Text('${_completeBudgetPercentage.toStringAsFixed(1)} %', style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
+                                        header: Padding(
+                                          padding: const EdgeInsets.symmetric(vertical: 12.0),
+                                          child: Text(
+                                              'Gesamt: ${formatToMoneyAmount(_completeBudgetExpenditures.toString())} / ${formatToMoneyAmount(_completeBudgetAmount.toString())}',
+                                              style: const TextStyle(fontSize: 16.0)),
+                                        ),
+                                        progressColor: _completeBudgetPercentage < 80.0
+                                            ? Colors.greenAccent
+                                            : _completeBudgetPercentage < 100.0
+                                                ? Colors.yellowAccent.shade700
+                                                : Colors.redAccent,
+                                        arcType: ArcType.HALF,
+                                        circularStrokeCap: CircularStrokeCap.round,
+                                        arcBackgroundColor: Colors.grey,
+                                        animation: true,
+                                        animateFromLastPercent: true,
+                                        animationDuration: 1000,
+                                      ),
+                                    ],
                                   ),
                                 ),
                               ),
                             ),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 6.0, left: 8.0, right: 8.0),
+                              child: Text(
+                                _completeBudgetPercentage <= 100.0
+                                    ? 'Du kannst über alle Budgets noch ' +
+                                        formatToMoneyAmount(((_completeBudgetAmount - _completeBudgetExpenditures) /
+                                                (DateTime(_selectedDate.year, _selectedDate.month + 1, 0).day - DateTime.now().day + 1))
+                                            .toString()) +
+                                        ' / Tag ausgeben'
+                                    : 'Du hast dein Gesamtbudget um ' + formatToMoneyAmount((_completeBudgetExpenditures - _completeBudgetAmount).toString()) + ' überzogen',
+                                style: const TextStyle(fontSize: 12.0, color: Colors.grey),
+                              ),
+                            ),
                             const Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 6.0),
+                              padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
                               child: Divider(),
                             ),
                             Expanded(
@@ -138,7 +157,6 @@ class _BudgetsScreenState extends State<BudgetsScreen> {
                                 color: Colors.cyanAccent,
                                 child: ListView.builder(
                                   scrollDirection: Axis.vertical,
-                                  shrinkWrap: true,
                                   itemCount: _budgetList.length,
                                   itemBuilder: (BuildContext context, int index) {
                                     return BudgetCard(budget: _budgetList[index], selectedDate: _selectedDate);


### PR DESCRIPTION
- In der Gesamtübersicht und bei jeder einzelnen Budget Karte wird nun angezeigt wieviel der Benutzer pro Tag noch im Durchschnitt ausgeben darf, um das Budget nicht zu überziehen.
- Wenn der Benutzer ein Budget überzogen hat wird ihm angezeigt um wieviel er das Budget überzogen hat.
- Über das Statistiken Icon kann der Benutzer direkt zu der Kategorie Ausgaben Seite wechseln und sehen was er alles diesen Monat für diese Kategorie ausgegeben hat und ggf. Kostenfallen identifizieren.
- Karten UI wurde übersichtlicher gestaltet.
- Kleinere UI/UX Themen wurden bei Budget Übersichtsseite verbessert.