### PR TITLE
Bugfix Wiederholungen

### DIFF
--- a/lib/components/input_fields/date_input_field.dart
+++ b/lib/components/input_fields/date_input_field.dart
@@ -46,11 +46,12 @@ class DateInputField extends StatelessWidget {
                               cubit.updateBookingRepeat(RepeatType.values[index].name),
                               if (RepeatType.values[index].name == RepeatType.beginningOfMonth.name)
                                 {
-                                  cubit.updateBookingDate(DateTime(DateTime.now().year, DateTime.now().month + 1, 1)),
+                                  cubit.updateBookingDate(DateTime(DateTime.now().year, DateTime.now().month + 1, 1).toString()),
                                 }
                               else if (RepeatType.values[index].name == RepeatType.endOfMonth.name)
                                 {
-                                  cubit.updateBookingDate(DateTime(DateTime.now().year, DateTime.now().month, DateTime(DateTime.now().year, DateTime.now().month + 1, 0).day)),
+                                  cubit.updateBookingDate(
+                                      DateTime(DateTime.now().year, DateTime.now().month, DateTime(DateTime.now().year, DateTime.now().month + 1, 0).day).toString()),
                                 },
                               Navigator.pop(context),
                             },


### PR DESCRIPTION
- Die Wiederholungsart "Am Monatsanfang" oder "Am Monatsende" kann wieder richtig ausgewählt werden => DateTime musste zu String konvertiert werden.