### PR TITLE
Kategorien Übersicht Bugfix

### DIFF
--- a/lib/components/cards/budget_card.dart
+++ b/lib/components/cards/budget_card.dart
@@ -40,7 +40,7 @@ class _BudgetCardState extends State<BudgetCard> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => Navigator.pushNamed(context, categorieAmountListRoute, arguments: CategorieAmountListScreenArguments(widget.selectedDate, widget.budget.categorie)),
+      onTap: () => Navigator.pushNamed(context, categorieAmountListRoute, arguments: CategorieAmountListScreenArguments(widget.selectedDate, widget.budget.categorie, '')),
       child: Card(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(14.0),
@@ -128,8 +128,8 @@ class _BudgetCardState extends State<BudgetCard> {
                             Icons.bar_chart_rounded,
                             size: 28.0,
                           ),
-                          onPressed: () =>
-                              Navigator.pushNamed(context, categorieAmountListRoute, arguments: CategorieAmountListScreenArguments(widget.selectedDate, widget.budget.categorie)),
+                          onPressed: () => Navigator.pushNamed(context, categorieAmountListRoute,
+                              arguments: CategorieAmountListScreenArguments(widget.selectedDate, widget.budget.categorie, '')),
                         ),
                       ),
                     ),

--- a/lib/components/cards/categorie_percentage_card.dart
+++ b/lib/components/cards/categorie_percentage_card.dart
@@ -13,11 +13,13 @@ class CategoriePercentageCard extends StatefulWidget {
   final PercentageStats percentageStats;
   final DateTime? selectedDate;
   final List<Booking> bookingList;
+  final String transactionType;
 
   const CategoriePercentageCard({
     Key? key,
     required this.percentageStats,
     required this.bookingList,
+    required this.transactionType,
     this.selectedDate,
   }) : super(key: key);
 
@@ -140,7 +142,7 @@ class _CategoriePercentageCardState extends State<CategoriePercentageCard> {
                             child: IconButton(
                               icon: const Icon(Icons.bar_chart_rounded),
                               onPressed: () => Navigator.pushNamed(context, categorieAmountListRoute,
-                                  arguments: CategorieAmountListScreenArguments(widget.selectedDate!, widget.percentageStats.name)),
+                                  arguments: CategorieAmountListScreenArguments(widget.selectedDate!, widget.percentageStats.name, widget.transactionType)),
                               padding: const EdgeInsets.only(right: 6.0),
                             ),
                           ),

--- a/lib/components/tab_bar/bookings_tab_bar.dart
+++ b/lib/components/tab_bar/bookings_tab_bar.dart
@@ -112,7 +112,9 @@ class _BookingsTabBarState extends State<BookingsTabBar> {
             Expanded(
               child: TabBarView(
                 children: <Widget>[
-                  _selectedTabOption[0] ? MonthlyBookingTabView(selectedDate: _selectedDate, categorie: '', account: '') : YearlyBookingTabView(selectedDate: _selectedDate),
+                  _selectedTabOption[0]
+                      ? MonthlyBookingTabView(selectedDate: _selectedDate, categorie: '', account: '', transactionType: '')
+                      : YearlyBookingTabView(selectedDate: _selectedDate),
                   _selectedTabOption[0] ? MonthlyStatisticsTabView(selectedDate: _selectedDate) : YearlyStatisticsTabView(selectedDate: _selectedDate),
                 ],
               ),

--- a/lib/components/tab_views/monthly_booking_tab_view.dart
+++ b/lib/components/tab_views/monthly_booking_tab_view.dart
@@ -21,6 +21,7 @@ class MonthlyBookingTabView extends StatefulWidget {
   DateTime selectedDate;
   final String categorie;
   final String account;
+  final String transactionType;
   final bool showOverviewTile;
   final bool showBarChart;
 
@@ -29,6 +30,7 @@ class MonthlyBookingTabView extends StatefulWidget {
     required this.selectedDate,
     required this.categorie,
     required this.account,
+    required this.transactionType,
     this.showOverviewTile = true,
     this.showBarChart = false,
   }) : super(key: key);
@@ -44,7 +46,7 @@ class _MonthlyBookingTabViewState extends State<MonthlyBookingTabView> {
   BookingRepository bookingRepository = BookingRepository();
 
   Future<List<Booking>> _loadMonthlyBookingList() async {
-    _bookingList = await bookingRepository.loadMonthlyBookingList(widget.selectedDate.month, widget.selectedDate.year, widget.categorie, widget.account);
+    _bookingList = await bookingRepository.loadMonthlyBookingList(widget.selectedDate.month, widget.selectedDate.year, widget.categorie, widget.account, widget.transactionType);
     _prepareMaps(_bookingList);
     _getTodayExpenditures(_bookingList);
     _getTodayRevenues(_bookingList);

--- a/lib/components/tab_views/monthly_statistics_tab_view.dart
+++ b/lib/components/tab_views/monthly_statistics_tab_view.dart
@@ -174,7 +174,8 @@ class _MonthlyStatisticsTabViewState extends State<MonthlyStatisticsTabView> {
                       child: ListView.builder(
                         itemCount: _percentageStats.length,
                         itemBuilder: (BuildContext context, int index) {
-                          return CategoriePercentageCard(percentageStats: _percentageStats[index], selectedDate: widget.selectedDate, bookingList: _bookingList);
+                          return CategoriePercentageCard(
+                              percentageStats: _percentageStats[index], selectedDate: widget.selectedDate, bookingList: _bookingList, transactionType: _currentCategorieType);
                         },
                       ),
                     ),

--- a/lib/components/tab_views/yearly_statistics_tab_view.dart
+++ b/lib/components/tab_views/yearly_statistics_tab_view.dart
@@ -177,7 +177,8 @@ class _YearlyStatisticsTabViewState extends State<YearlyStatisticsTabView> {
                       child: ListView.builder(
                         itemCount: _percentageStats.length,
                         itemBuilder: (BuildContext context, int index) {
-                          return CategoriePercentageCard(percentageStats: _percentageStats[index], selectedDate: widget.selectedDate, bookingList: _bookingList);
+                          return CategoriePercentageCard(
+                              percentageStats: _percentageStats[index], selectedDate: widget.selectedDate, bookingList: _bookingList, transactionType: _currentCategorieType);
                         },
                       ),
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:haushaltsbuch/screens/budget_screens/overview_one_subbudget_screen.dart';
 import 'package:hive_flutter/adapters.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -54,6 +53,7 @@ import 'screens/account_screens/account_details_screen.dart';
 import 'screens/budget_screens/create_budget_screen.dart';
 import 'screens/categorie_screens/categorie_amount_list_screen.dart';
 import 'screens/budget_screens/overview_one_budget_screen.dart';
+import 'screens/budget_screens/overview_one_subbudget_screen.dart';
 import 'screens/other_screens/settings_screen.dart';
 import 'screens/other_screens/splash_screen.dart';
 
@@ -201,6 +201,7 @@ class BudgetBookApp extends StatelessWidget {
               builder: (BuildContext context) => CategorieAmountListScreen(
                 selectedDate: args.selectedDate,
                 categorie: args.categorie,
+                transactionType: args.transactionType,
               ),
               settings: settings,
             );

--- a/lib/models/booking/booking_repository.dart
+++ b/lib/models/booking/booking_repository.dart
@@ -331,16 +331,33 @@ class BookingRepository extends BookingInterface {
   }
 
   @override
-  Future<List<Booking>> loadMonthlyBookingList(int selectedMonth, int selectedYear, [String categorie = '', String account = '']) async {
+  Future<List<Booking>> loadMonthlyBookingList(int selectedMonth, int selectedYear, [String categorie = '', String account = '', String transactionType = '']) async {
     var bookingBox = await Hive.openBox(bookingsBox);
     List<Booking> bookingList = [];
     for (int i = 0; i < bookingBox.length; i++) {
       Booking booking = await bookingBox.getAt(i);
-      if ((DateTime.parse(booking.date).month == selectedMonth && DateTime.parse(booking.date).year == selectedYear && categorie == '' && account == '') ||
-          (DateTime.parse(booking.date).month == selectedMonth && DateTime.parse(booking.date).year == selectedYear && categorie != '' && booking.categorie == categorie) ||
-          (DateTime.parse(booking.date).month == selectedMonth && DateTime.parse(booking.date).year == selectedYear && account != '' && booking.fromAccount == account)) {
-        booking.boxIndex = i;
-        bookingList.add(booking);
+      // TODO Code verbessern?!
+      if (transactionType == TransactionType.income.pluralName) {
+        transactionType = TransactionType.income.name;
+      } else if (transactionType == TransactionType.outcome.pluralName) {
+        transactionType = TransactionType.outcome.name;
+      }
+      if (DateTime.parse(booking.date).month == selectedMonth && DateTime.parse(booking.date).year == selectedYear) {
+        if (categorie == '' && account == '' && transactionType == '') {
+          booking.boxIndex = i;
+          bookingList.add(booking);
+          continue;
+        }
+        if (transactionType != '' && booking.transactionType == transactionType && categorie != '' && booking.categorie == categorie) {
+          booking.boxIndex = i;
+          bookingList.add(booking);
+          continue;
+        }
+        if (account != '' && booking.fromAccount == account) {
+          booking.boxIndex = i;
+          bookingList.add(booking);
+          continue;
+        }
       }
     }
     bookingList.sort((first, second) => second.date.compareTo(first.date));

--- a/lib/models/screen_arguments/categorie_amount_list_screen_arguments.dart
+++ b/lib/models/screen_arguments/categorie_amount_list_screen_arguments.dart
@@ -1,9 +1,11 @@
 class CategorieAmountListScreenArguments {
   final DateTime selectedDate;
   final String categorie;
+  final String transactionType;
 
   CategorieAmountListScreenArguments(
     this.selectedDate,
     this.categorie,
+    this.transactionType,
   );
 }

--- a/lib/screens/account_screens/account_details_screen.dart
+++ b/lib/screens/account_screens/account_details_screen.dart
@@ -70,6 +70,7 @@ class _AccountDetailsScreenState extends State<AccountDetailsScreen> {
           MonthlyBookingTabView(
             selectedDate: _selectedDate,
             categorie: '',
+            transactionType: '',
             account: widget.account.name,
             showOverviewTile: false,
           ),

--- a/lib/screens/categorie_screens/categorie_amount_list_screen.dart
+++ b/lib/screens/categorie_screens/categorie_amount_list_screen.dart
@@ -5,11 +5,13 @@ import '/components/tab_views/monthly_booking_tab_view.dart';
 class CategorieAmountListScreen extends StatefulWidget {
   final DateTime selectedDate;
   final String categorie;
+  final String transactionType;
 
   const CategorieAmountListScreen({
     Key? key,
     required this.selectedDate,
     required this.categorie,
+    required this.transactionType,
   }) : super(key: key);
 
   @override
@@ -28,6 +30,7 @@ class _CategorieAmountListScreenState extends State<CategorieAmountListScreen> {
               selectedDate: widget.selectedDate,
               categorie: widget.categorie,
               account: '',
+              transactionType: widget.transactionType,
               showOverviewTile: false,
               showBarChart: true,
             ),


### PR DESCRIPTION
- Wenn es gleiche Kategorienamen in Ausgaben und Einnahmen gibt werden nicht mehr von beiden Kategorien die Buchungen in der Kategorien Übersicht angezeigt, sondern nur noch Ausgaben oder nur noch Einnahmen, je nachdem welches Diagramm Icon der Benutzer davor angeklickt hat.