### PR TITLE
Serienbuchung Bug behoben

### DIFF
--- a/lib/components/input_fields/date_input_field.dart
+++ b/lib/components/input_fields/date_input_field.dart
@@ -142,6 +142,11 @@ class DateInputField extends StatelessWidget {
             );
             if (parsedDate != null) {
               cubit.updateBookingDate(parsedDate.toString());
+              if (cubit.state.bookingRepeat == RepeatType.beginningOfMonth.name && parsedDate.day != 1) {
+                cubit.updateBookingRepeat(RepeatType.noRepetition.name);
+              } else if (cubit.state.bookingRepeat == RepeatType.endOfMonth.name && parsedDate.day == 0) {
+                cubit.updateBookingRepeat(RepeatType.noRepetition.name);
+              }
             }
           },
         ),


### PR DESCRIPTION
- Wenn ein Benutzer bei einer Serienbuchung "Am Monatsanfang" auswählt und anschließend das Datum manuell nochmals ändert auf z.B. den 14.03.2024 wird die Serienbuchung zurückgesetzt auf noRepetition. Bei "Am Monatsende" ebenfalls. Außer der Benutzer wählt manuell den 1. oder den letzten Tag eines Monats, dann bleibt die Serienbuchung vorhanden.